### PR TITLE
Consistent style for templates + fix badges in README

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 
 <!-- This is just a template - feel free to delete any and all of it and replace as appropriate. -->
 
-### Description
+## Description
 
 <!--
 * Please share a clear and concise description of the problem.
@@ -34,7 +34,7 @@ GitHub's syntax highlighting supports more languages that would be practical to 
 Here's the complete list: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
 -->
 
-### Configuration
+## Configuration
 
 <!--
 * Which kind of projects are you using Buildvana SDK for?
@@ -43,13 +43,13 @@ Here's the complete list: https://github.com/github/linguist/blob/master/lib/lin
 * Do you know whether the problem is specific to that configuration?
   -->
 
-### Regression?
+## Regression?
 
 <!--
 * Did this work in a previous release? If you can try a previous release to find out, that can help us narrow down the problem. If you don't know, that's OK.
   -->
 
-### Other information
+## Other information
 
 <!--
 * Please include any relevant error messages. Please prefer pasted text over images (so it shows up in searches).

--- a/README.md
+++ b/README.md
@@ -3,14 +3,12 @@
 Part of [the Buildvana project](https://github.com/Buildvana/Buildvana).
 
 [![License](https://img.shields.io/github/license/Buildvana/Buildvana.Sdk.svg)](https://github.com/Buildvana/Buildvana.Sdk/blob/master/LICENSE)
-[![NuGet downloads](https://img.shields.io/nuget/dt/Buildvana.Sdk.svg?style=flat&logo=NuGet)](https://nuget.org/packages/Buildvana.Sdk)
-![GitHub downloads](https://img.shields.io/github/downloads/Buildvana/Buildvana.Sdk/total.svg?style=flat&logo=GitHub)
-[![Release date](https://img.shields.io/github/release-date/Buildvana/Buildvana.Sdk.svg)](https://github.com/Buildvana/Buildvana.Sdk/releases)
+[![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/Buildvana/Buildvana.Sdk?include_prereleases)](https://github.com/Buildvana/Buildvana.Sdk/releases)
+[![Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog%20v1.0.0-%23E05735)](https://github.com/Buildvana/Buildvana.Sdk/blob/master/CHANGELOG.md)
 
 [![Last commit](https://img.shields.io/github/last-commit/Buildvana/Buildvana.Sdk.svg)](https://github.com/Buildvana/Buildvana.Sdk/commits/master)
 [![Open issues](https://img.shields.io/github/issues-raw/Buildvana/Buildvana.Sdk.svg?label=open+issues)](https://github.com/Buildvana/Buildvana.Sdk/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
 [![Closed issues](https://img.shields.io/github/issues-closed-raw/Buildvana/Buildvana.Sdk.svg?label=closed+issues)](https://github.com/Buildvana/Buildvana.Sdk/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc)
-[![Changelog](https://img.shields.io/badge/changelog-Keep%20a%20Changelog%20v1.0.0-%23E05735)](https://github.com/Buildvana/Buildvana.Sdk/blob/master/CHANGELOG.md)
 
 [![Slack](https://img.shields.io/badge/join_us-on_Slack-ff7fc0.svg?logo=slack)](https://join.slack.com/t/buildvana/shared_invite/zt-e667rvy8-hCtADFiuF8OuiYvthIiWVw)
 


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix
- [ ] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation update
- [ ] Other (please describe below)

## Proposed changes / fixed issues

- The bug report template has level 3 headings, while the enhancement proposal template has level 2 headings. They should have consistent styles.
- Some badges in `README.md` do not work; plus, the NuGet downloads badge makes no sense since this project is only distributed via GitHub Packages.

## Checklist

- [x] My contribution is either my original work, or comes from projects with an MIT-compatible license, in which case I have updated the THIRD-PARTY-NOTICES file accordingly
- [ ] I have added and/or updated related documentation (if applicable)

## Other information

I put level 2 headings in the bug report template to make it consistent with both enhancement proposal and PR templates.
