### PR TITLE
Fix typo in labels.json.

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -5,7 +5,7 @@
     { "name": "area-assembly_info", "color": "ccc", "description": "[issue/PR] affects the AssemblyInfo module." },
     { "name": "area-assembly_signing", "color": "ccc", "description": "[issue/PR] affects the AssemblySigning module." },
     { "name": "area-jetbrains_annotations", "color": "ccc", "description": "[issue/PR] affects the JetBrainsAnnotations module." },
-    { "name": "area-literal_assembly_attributesk", "color": "ccc", "description": "[issue/PR] affects the LiteralAssemblyAttributes module." },
+    { "name": "area-literal_assembly_attributes", "color": "ccc", "description": "[issue/PR] affects the LiteralAssemblyAttributes module." },
     { "name": "area-nuget_pack", "color": "ccc", "description": "[issue/PR] affects the NuGetPack module." },
     { "name": "area-parse_version_file", "color": "ccc", "description": "[issue/PR] affects the ParseVersionFile module." },
     { "name": "area-standard_analyzers", "color": "ccc", "description": "[issue/PR] affects the StandardAnalyzers module." },


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix
- [ ] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [x] Other (please describe below)

## Proposed changes / fixed issues

The `area:literal-assembly-attributesk` label should be `area:literal-assembly-attributes`.

## Checklist

- [x] My contribution is either my original work, or comes from projects with an MIT-compatible license, in which case I have updated the THIRD-PARTY-NOTICES file accordingly
- [ ] I have added and/or updated related documentation (if applicable)
- [ ] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/master/CHANGELOG.md) according to the modifications I made

## Other information
