### PR TITLE
Fix the LiteralAssemblyAttributes module, closing #30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased changes
 
-No unreleased changes so far.
+### Updated
+- #30 The LiteralAssemblyAttributes module now works as expected.
 
 ## [1.0.0-alpha.3](https://github.com/Buildvana/Buildvana.Sdk/releases/tag/1.0.0-alpha.3) (2020-09-14)
 
 ### Added
 
-- **[potentially breaking]** A unit test project is now recognized as such, by convention, if its name ends with `.Tests`.  
+- **[potentially breaking]** #26 A unit test project is now recognized as such, by convention, if its name ends with `.Tests`.  
   To opt out of this convention, explicitly set `IsTestProject` to `true` or `false`.
 
 ### Updated
@@ -24,7 +25,7 @@ No unreleased changes so far.
 
 ### Added
 
-- Warning CA1707 (Identifiers should not contain underscores) is now suppressed by default in test projects. You can control this feature via the `AllowUnderscoresInMemberNames` property.
+- #22 Warning CA1707 (Identifiers should not contain underscores) is now suppressed by default in test projects. You can control this feature via the `AllowUnderscoresInMemberNames` property.
 
 ## [1.0.0-alpha.1](https://github.com/Buildvana/Buildvana.Sdk/releases/tag/1.0.0-alpha.1) (2020-09-12)
 

--- a/src/Buildvana.Sdk/Modules/LiteralAssemblyAttributes/AfterModules.targets
+++ b/src/Buildvana.Sdk/Modules/LiteralAssemblyAttributes/AfterModules.targets
@@ -10,9 +10,13 @@
        see the generated assembly info. There is at least one scenario involving Xaml
        where CoreCompile is invoked without other potential hooks such as Compile or CoreBuild,
        etc., so we hook directly on to CoreCompile. Furthermore, we  must run *after*
-       PrepareForBuild to ensure that the intermediate directory has been created. -->
+       PrepareForBuild to ensure that the intermediate directory has been created.
+       
+
+      Targets that generate Compile items are also expected to run before
+      BeforeCompile targets (common targets convention). -->
   <Target Name="BV_GenerateLiteralAssemblyInfo"
-          BeforeTargets="CoreCompile"
+          BeforeTargets="BeforeCompile;CoreCompile"
           DependsOnTargets="PrepareForBuild;BV_GenerateLiteralAssemblyInfoCore"
           Condition="'$(GenerateLiteralAssemblyInfo)' == 'true'" />
 
@@ -27,7 +31,7 @@
     </PropertyGroup>
 
     <!-- We only use up to _Parameter1 for most attributes, but other targets may add additional assembly attributes with multiple parameters. -->
-    <Hash ItemsToHash="@(LiteralAssemblyAttribute->'%(Identity)%(_Parameter1)%(_Parameter2)%(_Parameter3)%(_Parameter4)%(_Parameter5)%(_Parameter6)%(_Parameter7)%(_Parameter8)')">
+    <Hash ItemsToHash="@(LiteralAssemblyAttribute->'%(Identity)%(_Parameter1)%(_Parameter2)%(_Parameter3)%(_Parameter4)%(_Parameter5)%(_Parameter6)%(_Parameter7)%(_Parameter8)%(_Parameter9)%(_Parameter10)')">
       <Output TaskParameter="HashResult" PropertyName="BV_LiteralAssemblyAttributesHash" />
     </Hash>
 
@@ -45,10 +49,17 @@
           Inputs="$(BV_GeneratedLiteralAssemblyInfoInputsCacheFile)"
           Outputs="$(GeneratedLiteralAssemblyInfoFile)">
 
-    <Buildvana.Tasks.WriteLiteralAssemblyAttributes LiteralAssemblyAttributes="@(LiteralAssemblyAttribute)" Language="$(Language)" OutputFile="$(GeneratedLiteralAssemblyInfoFile)">
-      <Output TaskParameter="OutputFile" ItemName="Compile" />
-      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
-    </Buildvana.Tasks.WriteLiteralAssemblyAttributes>
+    <Buildvana.Tasks.WriteLiteralAssemblyAttributes
+      LiteralAssemblyAttributes="@(LiteralAssemblyAttribute)"
+      Language="$(Language)"
+      OutputPath="$(GeneratedLiteralAssemblyInfoFile)" />
+
+    <ItemGroup>
+      <Compile Remove="$(GeneratedLiteralAssemblyInfoFile)" />
+      <Compile Include="$(GeneratedLiteralAssemblyInfoFile)" />
+      <FileWrites Remove="$(GeneratedLiteralAssemblyInfoFile)" />
+      <FileWrites Include="$(GeneratedLiteralAssemblyInfoFile)" />
+    </ItemGroup>
 
   </Target>
 

--- a/src/Buildvana.Sdk/Modules/LiteralAssemblyAttributes/Module.props
+++ b/src/Buildvana.Sdk/Modules/LiteralAssemblyAttributes/Module.props
@@ -4,8 +4,7 @@
     <ParameterGroup>
       <Language ParameterType="System.String" Required="true" />
       <LiteralAssemblyAttributes ParameterType="Microsoft.Build.Framework.ITaskItem[]" />
-      <OutputDirectory ParameterType="Microsoft.Build.Framework.ITaskItem" />
-      <OutputFile ParameterType="Microsoft.Build.Framework.ITaskItem" Output="true" />
+      <OutputPath ParameterType="System.String" Required="true" />
     </ParameterGroup>
     <Task>
       <Code Type="Class" Language="cs" Source="$(MSBuildThisFileDirectory)WriteLiteralAssemblyAttributes.cs" />


### PR DESCRIPTION
## Types of changes

- [x] Bugfix
- [ ] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other (please describe below)

## Proposed changes / fixed issues

The `LiteralAssemblyAttributes` module contains unfinished code. This PR completes it and makes it work.

Closes: #30

## Checklist

- [x] My contribution is either my original work, or comes from projects with an MIT-compatible license, in which case I have updated the THIRD-PARTY-NOTICES file accordingly
- [x] I have added and/or updated related documentation (if applicable)
- [x] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/master/CHANGELOG.md) according to the modifications I made

## Other information
