### PR TITLE
Fix implementation of #38

### DIFF
--- a/src/Buildvana.Sdk/Modules/JetBrainsAnnotations/Module.targets
+++ b/src/Buildvana.Sdk/Modules/JetBrainsAnnotations/Module.targets
@@ -3,12 +3,8 @@
   <!-- Add ReSharper-related package references where appropriate,
        except for no-targets projects. -->
   <ItemGroup Condition="$(UseJetBrainsAnnotations) And !$(BV_IsNoTargetsProject)">
-    <PackageReference Include="JetBrains.Annotations"
-                      IsImplicitlyDefined="true"
-                      PrivateAssets="All" />
-    <PackageReference Include="ReSharper.ExportAnnotations.Task"
-                      IsImplicitlyDefined="true"
-                      PrivateAssets="All" />
+    <BV_PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
+    <BV_PackageReference Include="ReSharper.ExportAnnotations.Task" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/Buildvana.Sdk/Modules/ReferenceAssemblies/Module.targets
+++ b/src/Buildvana.Sdk/Modules/ReferenceAssemblies/Module.targets
@@ -13,7 +13,10 @@
 
   <!-- Automagically add reference assemblies  - see https://github.com/dotnet/designs/pull/33 -->
   <ItemGroup Condition="'$(UseNETFrameworkReferenceAssemblies)' == 'true'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <BV_PackageReference
+      Include="Microsoft.NETFramework.ReferenceAssemblies"
+      PrivateAssets="all"
+      IncludeAssets="runtime; build; native; contentfiles; analyzers" />
   </ItemGroup>
 
 </Project>

--- a/src/Buildvana.Sdk/Modules/StandardAnalyzers/Module.targets
+++ b/src/Buildvana.Sdk/Modules/StandardAnalyzers/Module.targets
@@ -3,15 +3,15 @@
   <!-- Include standard analyzers. -->
   <ItemGroup Condition="$(UseStandardAnalyzers)">
     <!-- Configured via auto-discovered .editorconfig -->
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers"
-                      IsImplicitlyDefined="true" 
-                      PrivateAssets="All"
-                      IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <BV_PackageReference
+      Include="Microsoft.CodeAnalysis.FxCopAnalyzers"
+      PrivateAssets="All"
+      IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <!-- Configured via stylecop.json (or .stylecop.json) to include in AdditionalFiles -->
-    <PackageReference Include="StyleCop.Analyzers"
-                      IsImplicitlyDefined="true" 
-                      PrivateAssets="All"
-                      IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <BV_PackageReference
+      Include="StyleCop.Analyzers"
+      PrivateAssets="All"
+      IncludeAssets="runtime; build; native; contentfiles; analyzers" />
   </ItemGroup>
 
   <!-- Find a stylecop.json or .stylecop.json file to configure StyleCop.Analyzers. -->
@@ -38,10 +38,10 @@
 
   <!-- Include public API analyzers. -->
   <ItemGroup Condition="$(UsePublicApiAnalyzers)">
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers"
-                      IsImplicitlyDefined="true" 
-                      PrivateAssets="All"
-                      IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+    <BV_PackageReference
+      Include="Microsoft.CodeAnalysis.PublicApiAnalyzers"
+      PrivateAssets="All"
+      IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <None Remove="$(MSBuildProjectDirectory)\PublicAPI.Shipped.txt" />
     <None Remove="$(MSBuildProjectDirectory)\PublicAPI.Unshipped.txt" />
     <AdditionalFiles Include="$(MSBuildProjectDirectory)\PublicAPI.Shipped.txt" />

--- a/src/Buildvana.Sdk/Sdk/Sdk.targets
+++ b/src/Buildvana.Sdk/Sdk/Sdk.targets
@@ -1,4 +1,4 @@
-﻿<Project InitialTargets="BV_CheckSdkPropsImport;BV_ManagePackageReferences">
+﻿<Project InitialTargets="BV_CheckSdkPropsImport">
 
   <!-- Signal that Sdk.targets has been imported. -->
   <PropertyGroup>
@@ -64,6 +64,27 @@
   <!-- Import our package versions -->
   <Import Condition="$(BV_IsConfigured)" Project="$(MSBuildThisFileDirectory)PackageVersions.props" />
 
+  <ItemGroup>
+
+    <!-- Let PackageReference items override corresponding BV_PackageReference items -->
+    <BV_PackageReference Remove="@(PackageReference)" />
+
+    <!-- Let PackageVersion items override Version metadata in corresponding BV_PackageVersion items -->
+    <BV_PackageVersion Update="@(PackageVersion)" Version="%(PackageVersion.Version)" Condition="'$(ManagePackageVersionsCentrally)' == 'true'" />
+
+    <!-- Use BV_PackageVersion items to define Version metadata for BV_PackageReference items -->
+    <BV_PackageReference Update="@(BV_PackageVersion)" Version="%(BV_PackageVersion.Version)" />
+
+    <!-- Transform BV_PackageReference items into PackageReference items.
+         No need for PackageVersion items because our packages are defined implicitly.
+         The NoWarn metadata prevents a yellow triangle to appear on each of our packages in the project tree in VS2019 (tested on v16.7.3). -->
+    <PackageReference
+      Include="@(BV_PackageReference)"
+      IsImplicitlyDefined="true"
+      NoWarn="NU1604" />
+
+  </ItemGroup>
+
   <!-- Check whether Sdk.props has been imported.
        We cannot use EvaluationError for this,
        because the logic that handles it is in Sdk.props. -->
@@ -76,43 +97,5 @@
       File="$(MSBuildProjectFullPath)" />
 
   </Target>
-
-  <!-- Set versions for package references added by Buildvana SDK
-       when centrally-managed package versions are enabled -->
-  <Target Name="BV_SetPackageVersions_CentrallyManaged" Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
-
-    <!-- Remove overridden package versions -->
-    <ItemGroup>
-      <BV_PackageVersion Remove="%(PackageVersion.Identity)" />
-    </ItemGroup>
-
-    <!-- Add our package versions to PackageVersion items -->
-    <ItemGroup>
-      <PackageVersion Include="%(BV_PackageVersion.Identity)" Version="%(BV_PackageVersion.Version)" />
-    </ItemGroup>
-
-  </Target>
-
-  <!-- Set versions for package references added by Buildvana SDK
-       when centrally-managed package versions are disabled -->
-  <Target Name="BV_SetPackageVersions_NotCentrallyManaged" Condition="'$(ManagePackageVersionsCentrally)' != 'true'">
-
-    <!-- Remove overridden package versions -->
-    <ItemGroup>
-      <BV_PackageVersion Remove="%(PackageReference.Identity)" Condition="'%(PackageReference.Version)' != ''"/>
-    </ItemGroup>
-
-    <!-- Update PackageReference items with our versions -->
-    <ItemGroup>
-      <PackageReference Update="%(BV_PackageVersion.Identity)" Version="%(BV_PackageVersion.Version)" />
-    </ItemGroup>
-
-  </Target>
-
-  <Target
-    Name="BV_ManagePackageReferences"
-    DependsOnTargets="
-      BV_SetPackageVersions_CentrallyManaged;
-      BV_SetPackageVersions_NotCentrallyManaged" />
 
 </Project>


### PR DESCRIPTION
## Types of changes

- [x] Bugfix
- [ ] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other (please describe below)

## Proposed changes / fixed issues

PR #38 breaks builds with weird error messages: code NU1009, text mentioning the fact that out automagically referenced packages are implicitly defined and thus shouldn't be included by the project.

Turns out using task batching in #38 was a bad idea and there's a better way.

## Checklist

- [x] My contribution is either my original work, or comes from projects with an MIT-compatible license, in which case I have updated the THIRD-PARTY-NOTICES file accordingly
- [ ] I have added and/or updated related documentation (if applicable)
- [ ] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/master/CHANGELOG.md) according to the modifications I made

## Other information

**Internal implementation note:** "Our" package references are now added via `BV_PackageReference` items, as opposed to `PackageReference` items as had been so far.
