### PR TITLE
More TFMs for compiled tasks

### DIFF
--- a/Buildvana.Sdk.sln.DotSettings
+++ b/Buildvana.Sdk.sln.DotSettings
@@ -126,8 +126,11 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UserInterface/OverrideVsRefactorings/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Agostini/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Buildvana/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=prerelease/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=seealso/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=usings/@EntryIndexedValue">True</s:Boolean>
 	
 	
 	

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes to existing features
 
 - https://github.com/Buildvana/Buildvana.Sdk/pull/47 - The automatically-added package reference to `ReSharper.ExportAnnotations.Task` has been updated to version 1.3.0.
+- https://github.com/Buildvana/Buildvana.Sdk/pull/49 - Compiled tasks are built for more target frameworks, to cover a larger number of build environments and MSBuild / .NET (Core) / Visual Studio versions.
 
 ### Bugs fixed in this release
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,9 @@
 <Project>
 
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Build.Framework" Version="16.6.0" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="16.6.0" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.6.0" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="16.7.0" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="16.7.0" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Nullable" Version="1.3.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,11 +1,18 @@
 <Project>
 
   <ItemGroup>
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageVersion Include="Nullable" Version="1.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
+    <PackageVersion Include="Microsoft.Build.Framework" Version="15.9.20" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net46'">
     <PackageVersion Include="Microsoft.Build.Framework" Version="16.7.0" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="16.7.0" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="16.7.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageVersion Include="Nullable" Version="1.3.0" />
   </ItemGroup>
 
 </Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="Buildvana" value="https://nuget.pkg.github.com/Buildvana/index.json" />
-  </packageSources>
-</configuration>

--- a/docs/ErrorsAndWarnings.md
+++ b/docs/ErrorsAndWarnings.md
@@ -49,6 +49,7 @@ Each module, as well as the SDK itself, is assigned a contiguous range of 100 er
 | Error code | Message | Description |
 | ---------- | ------- | ----------- |
 | BVE1200 | Cannot extract key from '...'. | Either the specified `.pfx` file is missing, ot the wrong password (or no password) was given. |
+| BVE1201 | '...' does not contain a RSA private key. | The specified `.pfx` file does not contain a RSA private key to export. |
 
 | Warning code | Message | Description |
 | ------------ | ------- | ----------- |

--- a/docs/ErrorsAndWarnings.md
+++ b/docs/ErrorsAndWarnings.md
@@ -27,6 +27,7 @@ Each module, as well as the SDK itself, is assigned a contiguous range of 100 er
 | BVE1001 | Sdk.targets not imported. | `Sdk.props` was imported, but `Sdk.targets` was not. |
 | BVE1002 | Sdk.props and Sdk.targets are in different directories. | The `Version` attributes in the `<Import>` directives for `Sdk.props` and `Sdk.targets` do not match. |
 | BVE1003 | Home directory not defined. | No suitable value for the `HomeDirectory` property has been found. |
+| BVE1004 | Could not determine a suitable target framework for compiled tasks. | This may be an internal error of Buildvana.Sdk. Please [open an issue](https://github.com/Buildvana/Buildvana.Sdk/issues/new/choose) stating which build tool you are using (Visual Studio, `dotnet build`, `dotnet msbuild`...), its version, and any other information you may deem useful. |
 
 | Warning code | Message | Description |
 | ------------ | ------- | ----------- |

--- a/src/Buildvana.Sdk/Buildvana.Sdk.csproj
+++ b/src/Buildvana.Sdk/Buildvana.Sdk.csproj
@@ -15,7 +15,7 @@
 
   <PropertyGroup>
     <PackageType>MSBuildSdk</PackageType>
-    <PackageTags>build;msbuild;sdk;dotnet</PackageTags>
+    <PackageTags>build msbuild sdk dotnet</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
     <Serviceable>true</Serviceable>
     <BuildOutputTargetFolder>Sdk</BuildOutputTargetFolder> <!-- Pack build output in Sdk\$(TargetFramework)\ instead of lib\$(TargetFramework)\ -->

--- a/src/Buildvana.Sdk/Buildvana.Sdk.csproj
+++ b/src/Buildvana.Sdk/Buildvana.Sdk.csproj
@@ -34,8 +34,8 @@
 </PropertyGroup>
 
   <ItemGroup>
-    <None Include="Modules\**\*" Exclude="*.cs" Pack="true" PackagePath="%(Identity)" />
-    <None Include="Sdk\**\*" Pack="true" PackagePath="%(Identity)" />
+    <Content Include="Modules\**\*" Exclude="*.cs" PackagePath="%(Identity)" />
+    <Content Include="Sdk\**\*" PackagePath="%(Identity)" />
   </ItemGroup>
 
   <!-- Additional package content - a workaround for project items not allowing duplicates, even with different Link metadata -->
@@ -147,7 +147,7 @@
 
     <ItemGroup>
       <BV_CopiedAdditionalPackageContent Include="$(__IntermediateAdditionalPackageContentDir)**\*" />
-      <None Include="@(BV_CopiedAdditionalPackageContent)" Visible="false" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
+      <Content Include="@(BV_CopiedAdditionalPackageContent)" Visible="false" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
     </ItemGroup>
 
   </Target>

--- a/src/Buildvana.Sdk/Buildvana.Sdk.csproj
+++ b/src/Buildvana.Sdk/Buildvana.Sdk.csproj
@@ -14,7 +14,6 @@
   <!-- NuGet package configuration -->
 
   <PropertyGroup>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageType>MSBuildSdk</PackageType>
     <PackageTags>build;msbuild;sdk;dotnet</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>

--- a/src/Buildvana.Sdk/Buildvana.Sdk.csproj
+++ b/src/Buildvana.Sdk/Buildvana.Sdk.csproj
@@ -3,7 +3,7 @@
   <!-- Common properties -->
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net46;net472;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <Title>Buildvana SDK</Title>
     <Summary>An opinionated, best-practices-based, CI-friendly, VS-friendly, MSBuild-powered build system for .NET projects.</Summary>
     <Description>This assembly contains compiled tasks used by Buildvana SDK. Documentation for the SDK is available here: https://github.com/Buildvana/Buildvana.Sdk/blob/master/README.md</Description>

--- a/src/Buildvana.Sdk/Buildvana.Sdk.csproj
+++ b/src/Buildvana.Sdk/Buildvana.Sdk.csproj
@@ -29,7 +29,9 @@
   <PropertyGroup>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
-  </PropertyGroup>
+    <IncludeBuildOutput>true</IncludeBuildOutput>
+    <BuildOutputTargetFolder>Sdk</BuildOutputTargetFolder>
+</PropertyGroup>
 
   <ItemGroup>
     <None Include="Modules\**\*" Exclude="*.cs" Pack="true" PackagePath="%(Identity)" />
@@ -146,35 +148,6 @@
     <ItemGroup>
       <BV_CopiedAdditionalPackageContent Include="$(__IntermediateAdditionalPackageContentDir)**\*" />
       <None Include="@(BV_CopiedAdditionalPackageContent)" Visible="false" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
-    </ItemGroup>
-
-  </Target>
-
-  <!-- Include published binaries under Sdk folder in package. -->
-
-  <PropertyGroup>
-    <BeforePack>$(BeforePack);__PublishDll</BeforePack>
-  </PropertyGroup>
-  <Target Name="__PublishDll">
-
-    <PropertyGroup>
-      <__DllPublishPath>$(MSBuildThisFileDirectory)obj\$(Configuration)\PublishedDll\</__DllPublishPath>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <__DllTargetFramework Include="$(TargetFrameworks)" />
-    </ItemGroup>
-
-    <!-- Publish this project for each target framework. -->
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="Configuration=$(Configuration);PublishDir=$(__DllPublishPath)%(__DllTargetFramework.Identity);PublishProtocol=FileSystem;TargetFramework=%(__DllTargetFramework.Identity);SelfContained=false" />
-
-    <ItemGroup>
-      <!-- Include published output as content, setting appropriate package paths. -->
-      <Content Include="$(__DllPublishPath)%(__DllTargetFramework.Identity)\*" PackagePath="Sdk\%(__DllTargetFramework.Identity)\" Visible="false" />
-      <!-- Don't include .deps.json files. -->
-      <Content Remove="$(__DllPublishPath)%(__DllTargetFramework.Identity)\*.deps.json" />
-      <!-- Don't include .pdb files in non-debug configurations (i.e. Release). -->
-      <Content Remove="$(__DllPublishPath)%(__DllTargetFramework.Identity)\*.pdb" Condition="'$(Configuration)' != 'Debug'" />
     </ItemGroup>
 
   </Target>

--- a/src/Buildvana.Sdk/Buildvana.Sdk.csproj
+++ b/src/Buildvana.Sdk/Buildvana.Sdk.csproj
@@ -18,7 +18,6 @@
     <PackageTags>build msbuild sdk dotnet</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
     <Serviceable>true</Serviceable>
-    <BuildOutputTargetFolder>Sdk</BuildOutputTargetFolder> <!-- Pack build output in Sdk\$(TargetFramework)\ instead of lib\$(TargetFramework)\ -->
     <MinClientVersion>4.3</MinClientVersion> <!-- Minimum NuGet client version supporting SemVer 2.0 -->
     <NoWarn>$(NoWarn);NU5100</NoWarn> <!-- The assembly '...' is not inside the 'lib' folder and hence it won't be added as a reference. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn> <!-- Some target frameworks [...] do not have exact matches [in the lib folder]. -->
@@ -148,6 +147,35 @@
     <ItemGroup>
       <BV_CopiedAdditionalPackageContent Include="$(__IntermediateAdditionalPackageContentDir)**\*" />
       <None Include="@(BV_CopiedAdditionalPackageContent)" Visible="false" Pack="true" PackagePath="%(RecursiveDir)%(Filename)%(Extension)" />
+    </ItemGroup>
+
+  </Target>
+
+  <!-- Include published binaries under Sdk folder in package. -->
+
+  <PropertyGroup>
+    <BeforePack>$(BeforePack);__PublishDll</BeforePack>
+  </PropertyGroup>
+  <Target Name="__PublishDll">
+
+    <PropertyGroup>
+      <__DllPublishPath>$(MSBuildThisFileDirectory)obj\$(Configuration)\PublishedDll\</__DllPublishPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <__DllTargetFramework Include="$(TargetFrameworks)" />
+    </ItemGroup>
+
+    <!-- Publish this project for each target framework. -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Publish" Properties="Configuration=$(Configuration);PublishDir=$(__DllPublishPath)%(__DllTargetFramework.Identity);PublishProtocol=FileSystem;TargetFramework=%(__DllTargetFramework.Identity);SelfContained=false" />
+
+    <ItemGroup>
+      <!-- Include published output as content, setting appropriate package paths. -->
+      <Content Include="$(__DllPublishPath)%(__DllTargetFramework.Identity)\*" PackagePath="Sdk\%(__DllTargetFramework.Identity)\" Visible="false" />
+      <!-- Don't include .deps.json files. -->
+      <Content Remove="$(__DllPublishPath)%(__DllTargetFramework.Identity)\*.deps.json" />
+      <!-- Don't include .pdb files in non-debug configurations (i.e. Release). -->
+      <Content Remove="$(__DllPublishPath)%(__DllTargetFramework.Identity)\*.pdb" Condition="'$(Configuration)' != 'Debug'" />
     </ItemGroup>
 
   </Target>

--- a/src/Buildvana.Sdk/Buildvana.Sdk.csproj
+++ b/src/Buildvana.Sdk/Buildvana.Sdk.csproj
@@ -107,8 +107,6 @@
 
   </Target>
 
-  <!-- Create an intermediate folder with additional package content. Folder layout must mimic package layout. -->
-
   <Target Name="__CopyAdditionalPackageContentToIntermediateDirectory"
           AfterTargets="Build"
           DependsOnTargets="__ComputeAdditionalPackageContentPaths"
@@ -122,7 +120,7 @@
 
   </Target>
 
-  <!-- Clean additional package content intermediate driectory -->
+  <!-- Clean additional package content intermediate directory -->
 
   <Target Name="__CleanAdditionalPackageContentIntermediateDirectory"
           AfterTargets="BeforeClean"

--- a/src/Buildvana.Sdk/Buildvana.Sdk.csproj
+++ b/src/Buildvana.Sdk/Buildvana.Sdk.csproj
@@ -21,6 +21,7 @@
     <MinClientVersion>4.3</MinClientVersion> <!-- Minimum NuGet client version supporting SemVer 2.0 -->
     <NoWarn>$(NoWarn);NU5100</NoWarn> <!-- The assembly '...' is not inside the 'lib' folder and hence it won't be added as a reference. -->
     <NoWarn>$(NoWarn);NU5128</NoWarn> <!-- Some target frameworks [...] do not have exact matches [in the lib folder]. -->
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 
   <!-- Package contents (besides build output) -->

--- a/src/Buildvana.Sdk/Sdk/Sdk.props
+++ b/src/Buildvana.Sdk/Sdk/Sdk.props
@@ -52,10 +52,22 @@
   </PropertyGroup>
 
   <!-- Seelct TFM for compiled tasks -->
-  <PropertyGroup>
-    <BV_SdkTasksTfm Condition="'$(MSBuildRuntimeType)' != 'Core'">net472</BV_SdkTasksTfm>
-    <BV_SdkTasksTfm Condition="'$(MSBuildRuntimeType)' == 'Core'">netcoreapp2.1</BV_SdkTasksTfm>
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Full'">
+    <BV_SdkTasksTfm Condition="'$(MSBuildVersion)' &lt; '16.0'">net46</BV_SdkTasksTfm>
+    <BV_SdkTasksTfm Condition="'$(MSBuildVersion)' &gt;= '16.0'">net472</BV_SdkTasksTfm>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
+    <BV_SdkTasksTfm Condition="'$(MSBuildVersion)' &lt; '16.7'">netcoreapp2.1</BV_SdkTasksTfm>
+    <BV_SdkTasksTfm Condition="'$(MSBuildVersion)' &gt;= '16.7' And '$(MSBuildVersion)' &lt; '16.8'">netcoreapp3.1</BV_SdkTasksTfm>
+    <BV_SdkTasksTfm Condition="'$(MSBuildVersion)' &gt;= '16.8'">net5.0</BV_SdkTasksTfm>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Mono'">
+    <BV_SdkTasksTfm>net472</BV_SdkTasksTfm>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(BV_SdkTasksTfm)' == ''">
+    <EvaluationError Include="BVE1004"
+                     Text="Could not determine a suitable target framework for compiled tasks." />
+  </ItemGroup>
 
   <!-- Select compiled tasks assembly -->
   <PropertyGroup>

--- a/src/Buildvana.Sdk/Tasks/Internal/StringUtility.cs
+++ b/src/Buildvana.Sdk/Tasks/Internal/StringUtility.cs
@@ -12,7 +12,7 @@ using System.Runtime.CompilerServices;
 
 namespace Buildvana.Sdk.Tasks.Internal
 {
-    internal class StringUtility
+    internal static class StringUtility
     {
         // Like string.IsNullOrEmpty, but nullability-annotated for all platforms
         // https://github.com/dotnet/roslyn/issues/37995

--- a/src/Buildvana.Sdk/Tasks/LiteralAssemblyAttributes/Internal/AttributeDefinition.cs
+++ b/src/Buildvana.Sdk/Tasks/LiteralAssemblyAttributes/Internal/AttributeDefinition.cs
@@ -11,8 +11,12 @@ using System.Collections.Generic;
 
 namespace Buildvana.Sdk.Tasks.LiteralAssemblyAttributes.Internal
 {
-    internal interface ILiteralAssemblyAttributesGenerator
+    internal struct AttributeDefinition
     {
-        string GenerateCode(IEnumerable<AttributeDefinition> attributes);
+        public string Type;
+
+        public IReadOnlyCollection<string> OrderedParameters;
+
+        public IReadOnlyDictionary<string, string> NamedParameters;
     }
 }

--- a/src/Buildvana.Sdk/Tasks/LiteralAssemblyAttributes/Internal/LiteralAssemblyAttributesGeneratorBase`1.cs
+++ b/src/Buildvana.Sdk/Tasks/LiteralAssemblyAttributes/Internal/LiteralAssemblyAttributesGeneratorBase`1.cs
@@ -16,16 +16,16 @@ namespace Buildvana.Sdk.Tasks.LiteralAssemblyAttributes.Internal
     internal abstract class LiteralAssemblyAttributesGeneratorBase<TBuilder> : CodeGenerator<TBuilder>, ILiteralAssemblyAttributesGenerator
         where TBuilder : CodeBuilder, new()
     {
-        public string GenerateCode(IEnumerable<(string Type, IReadOnlyCollection<string> OrderedParameters, IReadOnlyDictionary<string, string> NamedParameters)> attributes)
+        public string GenerateCode(IEnumerable<AttributeDefinition> attributes)
         {
-            foreach (var (type, rawOrderedParameters, rawNamedParameters) in attributes)
+            foreach (var attribute in attributes)
             {
-                var orderedParameters = rawOrderedParameters.Select(TransformParameterValue).ToArray();
-                var namedParameters = rawNamedParameters.ToDictionary(
+                var orderedParameters = attribute.OrderedParameters.Select(TransformParameterValue).ToArray();
+                var namedParameters = attribute.NamedParameters.ToDictionary(
                     pair => pair.Key,
                     pair => TransformParameterValue(pair.Value));
 
-                GenerateAttribute(type, orderedParameters, namedParameters);
+                GenerateAttribute(attribute.Type, orderedParameters, namedParameters);
             }
 
             return GetGeneratedCode();

--- a/src/Buildvana.Sdk/Tasks/Resources/Strings.AssemblySigning.cs
+++ b/src/Buildvana.Sdk/Tasks/Resources/Strings.AssemblySigning.cs
@@ -14,6 +14,7 @@ namespace Buildvana.Sdk.Tasks.Resources
         public static class AssemblySigning
         {
             public const string CannotExtractKeyFmt = "BVE1200: Cannot extract key from '{0}'.";
+            public const string MissingRsaPrivateKey = "BVE1201: '{0}' does not contain a RSA private key.";
         }
     }
 }

--- a/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/Internal/CSharpThisAssemblyClassGenerator.cs
+++ b/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/Internal/CSharpThisAssemblyClassGenerator.cs
@@ -39,7 +39,7 @@ namespace Buildvana.Sdk.Tasks.ThisAssemblyClass.Internal
             NewLine("{");
         }
 
-        protected override void EndInternalStaticClass(string name) => NewLine("}");
+        protected override void EndInternalStaticClass() => NewLine("}");
 
         protected override void PublicConstant(string name, object value)
         {
@@ -62,7 +62,7 @@ namespace Buildvana.Sdk.Tasks.ThisAssemblyClass.Internal
                     Text('L');
                     break;
                 default:
-                    Text(value.ToString());
+                    Text(value.ToString() ?? string.Empty);
                     break;
             }
 

--- a/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/Internal/ConstantDefinition.cs
+++ b/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/Internal/ConstantDefinition.cs
@@ -7,12 +7,12 @@
 // See THIRD-PARTY-NOTICES file in the project root for third-party copyright notices.
 // -----------------------------------------------------------------------------------
 
-using System.Collections.Generic;
-
 namespace Buildvana.Sdk.Tasks.ThisAssemblyClass.Internal
 {
-    internal interface IThisAssemblyClassGenerator
+    internal struct ConstantDefinition
     {
-        string GenerateCode(string className, string classNamespace, IEnumerable<ConstantDefinition> constants);
+        public string Name;
+
+        public object Value;
     }
 }

--- a/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/Internal/ThisAssemblyClassGeneratorBase`1.cs
+++ b/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/Internal/ThisAssemblyClassGeneratorBase`1.cs
@@ -15,16 +15,16 @@ namespace Buildvana.Sdk.Tasks.ThisAssemblyClass.Internal
     internal abstract class ThisAssemblyClassGeneratorBase<TBuilder> : CodeGenerator<TBuilder>, IThisAssemblyClassGenerator
         where TBuilder : CodeBuilder, new()
     {
-        public string GenerateCode(string classNamespace, string className, IEnumerable<(string Name, object Value)> constants)
+        public string GenerateCode(string classNamespace, string className, IEnumerable<ConstantDefinition> constants)
         {
             BeginNamespace(classNamespace);
             BeginInternalStaticClass(className);
-            foreach (var (name, value) in constants)
+            foreach (var constant in constants)
             {
-                PublicConstant(name, value);
+                PublicConstant(constant.Name, constant.Value);
             }
 
-            EndInternalStaticClass(className);
+            EndInternalStaticClass();
             EndNamespace(classNamespace);
             return GetGeneratedCode();
         }
@@ -35,7 +35,7 @@ namespace Buildvana.Sdk.Tasks.ThisAssemblyClass.Internal
 
         protected abstract void BeginInternalStaticClass(string name);
 
-        protected abstract void EndInternalStaticClass(string name);
+        protected abstract void EndInternalStaticClass();
 
         protected abstract void PublicConstant(string name, object value);
     }

--- a/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/Internal/VisualBasicThisAssemblyClassGenerator.cs
+++ b/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/Internal/VisualBasicThisAssemblyClassGenerator.cs
@@ -34,7 +34,7 @@ namespace Buildvana.Sdk.Tasks.ThisAssemblyClass.Internal
             NewLine("End Sub");
         }
 
-        protected override void EndInternalStaticClass(string name) => NewLine("End Class");
+        protected override void EndInternalStaticClass() => NewLine("End Class");
 
         protected override void PublicConstant(string name, object value)
         {
@@ -57,7 +57,7 @@ namespace Buildvana.Sdk.Tasks.ThisAssemblyClass.Internal
                     Text('L');
                     break;
                 default:
-                    Text(value.ToString());
+                    Text(value.ToString() ?? string.Empty);
                     break;
             }
 

--- a/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/WriteThisAssemblyClass.cs
+++ b/src/Buildvana.Sdk/Tasks/ThisAssemblyClass/WriteThisAssemblyClass.cs
@@ -105,7 +105,7 @@ namespace Buildvana.Sdk.Tasks.ThisAssemblyClass
             return type != null;
         }
 
-        private (string Name, object Value) ExtractConstantDefinitionFromItem(ITaskItem item)
+        private static ConstantDefinition ExtractConstantDefinitionFromItem(ITaskItem item)
         {
             var name = item.ItemSpec.Trim();
             var typeStr = item.GetMetadata("Type").Trim();
@@ -130,7 +130,7 @@ namespace Buildvana.Sdk.Tasks.ThisAssemblyClass
                 throw new BuildErrorException(Strings.ThisAssemblyClass.InvalidConstantValueFmt, name, valueStr);
             }
 
-            return (name, value);
+            return new ConstantDefinition { Name = name, Value = value };
         }
     }
 }


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix
- [x] Enhancement (new and/or improved behavior)
- [x] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other (please describe below)

## Proposed changes / fixed issues

- Compile tasks for `net46;net472;netcoreapp2,1;netcoreapp3.1;net5.0`
- Select the appropriate compiled tasks assembly according to MSBuild version and runtime type
- Refactor compiled tasks to not use `ValueTuple` (which is not present in .NET Framework 4.6)
- Refactor the ConvertPfxToSnk task for cleaner code and no warnings
- Review the .csproj file to cleanly separate Pack from Build so CI can do them as separate steps
- Remove the `<dependencies>` tag from .nuspec files, so packages are not tied to any particular framework

Closes #48

## Checklist

- [x] My contribution is either my original work, or comes from projects with an MIT-compatible license, in which case I have updated the THIRD-PARTY-NOTICES file accordingly
- [ ] I have added and/or updated related documentation (if applicable)
- [x] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/master/CHANGELOG.md) according to the modifications I made

## Other information

I had to struggle with NuGet placing _all_ build output in the main package, including dependencies and JSON files. I even tried including _published_ output instead of build output, but then the Pack task wouldn't create the symbols package (error NU5017: no build output and no assemblies in package - which is not true, as both assemblies and symbol files were included as content, but mysterious are the ways of NuGet). Then, all of a sudden, it started to behave again and the included build output was exactly as expected: .dll files in the main package, .pdb files in the symbols package. Again: mysterious are the ways of NuGet. Anyway, now we have the simplest .csproj possible that produces correct packages, at the cost of some apparently insane commits.
