### PR TITLE
Fix non-Windows builds; rename EnableThisAssemblyClass and default to false; fix package description; improve actions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,58 @@
+area-core:
+  - "src/Buildvana.Sdk/Sdk/**/*"
+
+area-assembly_signing:
+  - "src/Buildvana.Sdk/Modules/AssemblySigning/**/*"
+  - "src/Buildvana.Sdk/Tasks/AssemblySigning/**/*"
+
+area-jetbrains_annotations:
+  - "src/Buildvana.Sdk/Modules/JetBrainsAnnotations/**/*"
+  - "src/Buildvana.Sdk/Tasks/JetBrainsAnnotations/**/*"
+
+area-literal_assembly_attributes:
+  - "src/Buildvana.Sdk/Modules/LiteralAssemblyAttributes/**/*"
+  - "src/Buildvana.Sdk/Tasks/LiteralAssemblyAttributes/**/*"
+
+area-nuget_pack:
+  - "src/Buildvana.Sdk/Modules/NuGetPack/**/*"
+  - "src/Buildvana.Sdk/Tasks/NuGetPack/**/*"
+
+area-standard_analyzers:
+  - "src/Buildvana.Sdk/Modules/StandardAnalyzers/**/*"
+  - "src/Buildvana.Sdk/Tasks/StandardAnalyzers/**/*"
+
+area-thisassembly_class:
+  - "src/Buildvana.Sdk/Modules/ThisAssemblyClass/**/*"
+  - "src/Buildvana.Sdk/Tasks/ThisAssemblyClass/**/*"
+
+area-version_file:
+  - "src/Buildvana.Sdk/Modules/VersionFile/**/*"
+  - "src/Buildvana.Sdk/Tasks/VersionFile/**/*"
+
+area-xml_documentation:
+  - "src/Buildvana.Sdk/Modules/XmlDocumentation/**/*"
+  - "src/Buildvana.Sdk/Tasks/XmlDocumentation/**/*"
+
+area-build:
+  - "**/*.csproj"
+  - "**/Common.props"
+  - "**/Common.targets"
+
 area-ci:
-  - any: ['.github/workflows/**/*']
+  - ".github/workflows/**/*"
 
 area-deps:
-  - "**/PackageVersions.props"
+  - "**/Directory.Packages.props"
+  - Directory.Build.props
+  - Directory.Build.targets
+  - "src/Buildvana.Sdk/Sdk/PackageVersions.props"
 
 area-docs:
-  - any: ['.github/**/*', '**/LICENSE', '**/README.md', '**/THIRD-PARTY-NOTICES']
+  - "docs/**/*"
+  - "**/README.md"
+  - "**/LICENSE"
+  - "**/THIRD-PARTY-NOTICES"
 
 area-repo:
-  - any: ['.github/*.yml', '.github/**/*.md']
+  - ".github/*.yml"
+  - ".github/**/*.md"

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -8,7 +8,7 @@
     { "name": "area-nuget_pack", "color": "ccc", "description": "[issue/PR] affects the NuGetPack module." },
     { "name": "area-standard_analyzers", "color": "ccc", "description": "[issue/PR] affects the StandardAnalyzers module." },
     { "name": "area-thisassembly_class", "color": "ccc", "description": "[issue/PR] affects the ThisAssemblyClass module." },
-    { "name": "area-version_file", "color": "ccc", "description": "[issue/PR] affects the ParseVersionFile module." },
+    { "name": "area-version_file", "color": "ccc", "description": "[issue/PR] affects the VersionFile module." },
     { "name": "area-xml_documentation", "color": "ccc", "description": "[issue/PR] affects the XmlDocumentation module." },
 
     { "name": "area-build", "color": "ccc", "description": "[issue/PR] affects project files and/or build settings." },

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,40 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  ContinuousIntegrationBuild: "true"
+  DOTNET_NOLOGO: "true"
+
+jobs:
+
+  test:
+    name: Unit testing and code coverage reporting
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+        net: [ 3.1.x, 5.0.100-rc.1.20452.10 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup .NET ${{ matrix.net }}
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ matrix.net }}
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build solution
+      run: dotnet build -c Release --no-restore /maxCpuCount:1
+
+    - name: Generate packages
+      run: dotnet pack -c Release --no-build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,8 +12,8 @@ env:
 
 jobs:
 
-  test:
-    name: Unit testing and code coverage reporting
+  build:
+    name: Build and pack on CI server
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        net: [ 3.1.x, 5.0.100-rc.1.20452.10 ]
+        net: [ 5.0.100-rc.1.20452.10 ]
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -18,6 +18,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Assign labels to pull request
-        uses: actions/labeler@main
+        uses: actions/labeler@2.2.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes to existing features
 
+- https://github.com/Buildvana/Buildvana.Sdk/pull/51 - The automatically-added package reference to `ReSharper.ExportAnnotations.Task` has been updated to version 1.3.1.
+- **potentially breaking** https://github.com/Buildvana/Buildvana.Sdk/pull/51 - The `EnableThisAssemblyClass` property has been renamed to `GenerateThisAssemblyClass` and its default value is now `false`.
+
 ### Bugs fixed in this release
+
+- Thanks to the `ReSharper.ExportAnnotations.Task` update, building a project on a non-Windows system will no longer fail. See https://github.com/tenacom/ReSharper.ExportAnnotations/issues/23 for details.
 
 ### Known problems introduced by this release
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,6 @@
 
   <!-- DO NOT MODIFY THIS FILE! Create or modify Common.props instead. -->
 
-  <Import Project="Sdk.props" Sdk="Buildvana.Sdk" Version="1.0.0-alpha.7" />
+  <Import Project="Sdk.props" Sdk="Buildvana.Sdk" Version="1.0.0-alpha.8" />
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,6 +2,6 @@
 
   <!-- DO NOT MODIFY THIS FILE! Create or modify Common.targets instead. -->
 
-  <Import Project="Sdk.targets" Sdk="Buildvana.Sdk" Version="1.0.0-alpha.7" />
+  <Import Project="Sdk.targets" Sdk="Buildvana.Sdk" Version="1.0.0-alpha.8" />
 
 </Project>

--- a/docs/ErrorsAndWarnings.md
+++ b/docs/ErrorsAndWarnings.md
@@ -140,7 +140,7 @@ Each module, as well as the SDK itself, is assigned a contiguous range of 100 er
 
 | Warning code | Message | Description |
 | ------------ | ------- | ----------- |
-| BVW1900 | Language '...' is not supported by ThisAssemblyClass. | Property `EnableThisAssemblyClass` was set to `true` in a project in a language that is neither C#, nor Visual Basic. The `ThisAssembly` class (or whatever name set via the `ThisAssemblyClassName` property) will not be created, possibly causing compilation errors. |
+| BVW1900 | Language '...' is not supported by ThisAssemblyClass. | Property `GenerateThisAssemblyClass` was set to `true` in a project in a language that is neither C#, nor Visual Basic. The `ThisAssembly` class (or whatever name set via the `ThisAssemblyClassName` property) will not be created, possibly causing compilation errors. |
 
 ## XmlDocumentation module (2000-2099)
 

--- a/docs/ErrorsAndWarnings.md
+++ b/docs/ErrorsAndWarnings.md
@@ -140,7 +140,7 @@ Each module, as well as the SDK itself, is assigned a contiguous range of 100 er
 
 | Warning code | Message | Description |
 | ------------ | ------- | ----------- |
-| BVW1900 | Language '...' is not supported by ThisAssemblyClass. | Property `GenerateThisAssemblyClass` was set to `true` in a project in a language that is neither C#, nor Visual Basic. The `ThisAssembly` class (or whatever name set via the `ThisAssemblyClassName` property) will not be created, possibly causing compilation errors. |
+| BVW1900 | ThisAssembly class generation is only supported in C# and Visual Basic projects. | Property `GenerateThisAssemblyClass` was set to `true` in a project in a language that is neither C#, nor Visual Basic. The `ThisAssembly` class (or whatever name set via the `ThisAssemblyClassName` property) will not be created, possibly causing compilation errors. |
 
 ## XmlDocumentation module (2000-2099)
 

--- a/src/Buildvana.Sdk/Buildvana.Sdk.csproj
+++ b/src/Buildvana.Sdk/Buildvana.Sdk.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <TargetFrameworks>net46;net472;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <Title>Buildvana SDK</Title>
-    <Summary>An opinionated, best-practices-based, CI-friendly, VS-friendly, MSBuild-powered build system for .NET projects.</Summary>
+    <Summary>An opinionated, best-practices-based, CI- / CLI- / VS-friendly, MSBuild-powered build system for .NET projects.</Summary>
     <Description>This assembly contains compiled tasks used by Buildvana SDK. Documentation for the SDK is available here: https://github.com/Buildvana/Buildvana.Sdk/blob/master/README.md</Description>
     <XmlDocs>false</XmlDocs> <!--Do not generate XML documentation -->
     <ExportJetBrainsAnnotations>false</ExportJetBrainsAnnotations> <!--Do not generate a .ExternalAnnotations.xml file -->
@@ -15,6 +15,7 @@
 
   <PropertyGroup>
     <PackageType>MSBuildSdk</PackageType>
+    <PackageDescription>$(Summary)</PackageDescription> <!-- The Description property is too specific to the compiled tasks assembly. -->
     <PackageTags>build msbuild sdk dotnet</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency>
     <Serviceable>true</Serviceable>

--- a/src/Buildvana.Sdk/Modules/ThisAssemblyClass/Module.targets
+++ b/src/Buildvana.Sdk/Modules/ThisAssemblyClass/Module.targets
@@ -8,7 +8,6 @@
   <!-- Coalesce EnableThisAssemblyClass to a boolean value; force to false for projects in unsupported languages. -->
   <PropertyGroup>
     <EnableThisAssemblyClass Condition="'$(Language)' != 'C#' And '$(Language)' != 'VB'">false</EnableThisAssemblyClass>
-    <EnableThisAssemblyClass Condition="'$(EnableThisAssemblyClass)' == ''">true</EnableThisAssemblyClass>
     <EnableThisAssemblyClass Condition="'$(EnableThisAssemblyClass)' != 'true'">false</EnableThisAssemblyClass>
   </PropertyGroup>
 

--- a/src/Buildvana.Sdk/Modules/ThisAssemblyClass/Module.targets
+++ b/src/Buildvana.Sdk/Modules/ThisAssemblyClass/Module.targets
@@ -1,24 +1,24 @@
 <Project>
 
-  <!-- Save the value of EnableThisAssemblyClass for later determination of whether to issue a warning. -->
+  <!-- Save the value of GenerateThisAssemblyClass for later determination of whether to issue a warning. -->
   <PropertyGroup>
-    <BV_EnableThisAssemblyClass>$(EnableThisAssemblyClass)</BV_EnableThisAssemblyClass>
+    <BV_SaveGenerateThisAssemblyClass>$(GenerateThisAssemblyClass)</BV_SaveGenerateThisAssemblyClass>
   </PropertyGroup>
 
-  <!-- Coalesce EnableThisAssemblyClass to a boolean value; force to false for projects in unsupported languages. -->
+  <!-- Coalesce GenerateThisAssemblyClass to a boolean value; force to false for projects in unsupported languages. -->
   <PropertyGroup>
-    <EnableThisAssemblyClass Condition="'$(Language)' != 'C#' And '$(Language)' != 'VB'">false</EnableThisAssemblyClass>
-    <EnableThisAssemblyClass Condition="'$(EnableThisAssemblyClass)' != 'true'">false</EnableThisAssemblyClass>
+    <GenerateThisAssemblyClass Condition="'$(Language)' != 'C#' And '$(Language)' != 'VB'">false</GenerateThisAssemblyClass>
+    <GenerateThisAssemblyClass Condition="'$(GenerateThisAssemblyClass)' != 'true'">false</GenerateThisAssemblyClass>
   </PropertyGroup>
 
-  <!-- Issue a warning if EnableThisAssemblyClass was set to true for a project in an unsupported language. -->
+  <!-- Issue a warning if GenerateThisAssemblyClass was set to true for a project in an unsupported language. -->
   <ItemGroup >
-    <EvaluationWarning Condition="'$(BV_EnableThisAssemblyClass)' == 'true' And !$(EnableThisAssemblyClass)"
+    <EvaluationWarning Condition="'$(BV_SaveGenerateThisAssemblyClass)' == 'true' And !$(GenerateThisAssemblyClass)"
                        Include="BVW1900"
                        Text="Language '$(Language)' is not supported by ThisAssemblyClass." />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Module.Core.targets"
-          Condition="$(EnableThisAssemblyClass)" />
+          Condition="$(GenerateThisAssemblyClass)" />
 
 </Project>

--- a/src/Buildvana.Sdk/Modules/ThisAssemblyClass/Module.targets
+++ b/src/Buildvana.Sdk/Modules/ThisAssemblyClass/Module.targets
@@ -1,21 +1,15 @@
 <Project>
 
-  <!-- Save the value of GenerateThisAssemblyClass for later determination of whether to issue a warning. -->
-  <PropertyGroup>
-    <BV_SaveGenerateThisAssemblyClass>$(GenerateThisAssemblyClass)</BV_SaveGenerateThisAssemblyClass>
-  </PropertyGroup>
-
   <!-- Coalesce GenerateThisAssemblyClass to a boolean value; force to false for projects in unsupported languages. -->
   <PropertyGroup>
-    <GenerateThisAssemblyClass Condition="'$(Language)' != 'C#' And '$(Language)' != 'VB'">false</GenerateThisAssemblyClass>
     <GenerateThisAssemblyClass Condition="'$(GenerateThisAssemblyClass)' != 'true'">false</GenerateThisAssemblyClass>
   </PropertyGroup>
 
-  <!-- Issue a warning if GenerateThisAssemblyClass was set to true for a project in an unsupported language. -->
-  <ItemGroup >
-    <EvaluationWarning Condition="'$(BV_SaveGenerateThisAssemblyClass)' == 'true' And !$(GenerateThisAssemblyClass)"
+  <!-- Issue a warning if GenerateThisAssemblyClass is set to true for a project in an unsupported language. -->
+  <ItemGroup Condition="'$(GenerateThisAssemblyClass)' == 'true'">
+    <EvaluationWarning Condition="'$(Language)' != 'C#' And '$(Language)' != 'VB'"
                        Include="BVW1900"
-                       Text="Language '$(Language)' is not supported by ThisAssemblyClass." />
+                       Text="ThisAssembly class generation is only supported in C# and Visual Basic projects." />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Module.Core.targets"

--- a/src/Buildvana.Sdk/Sdk/PackageVersions.props
+++ b/src/Buildvana.Sdk/Sdk/PackageVersions.props
@@ -11,7 +11,7 @@
     <BV_PackageVersion Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0" />
     <BV_PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.0" />
     <BV_PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
-    <BV_PackageVersion Include="ReSharper.ExportAnnotations.Task" Version="1.3.0" />
+    <BV_PackageVersion Include="ReSharper.ExportAnnotations.Task" Version="1.3.1" />
     <BV_PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.205" />
   </ItemGroup>
 


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix
- [ ] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [x] Dependencies added, updated, or removed
- [x] Build related changes
- [x] CI related changes
- [x] Documentation update
- [x] Other (please describe below)

## Proposed changes / fixed issues

- Update ReSharper.ExportAnnotations.Task to v1.3.1 to fix builds failing on non-Windows systems because of https://github.com/tenacom/ReSharper.ExportAnnotations/issues/23
- Rename the `EnableThisAssemblyClass` property to a more appropriate `GenerateThisAssemblyClass` and set it to false by default
- Separate package description from assembly description, as the latter is about the mere assembly, while the former has to represent Buildvana.Sdk in package seacrhes.
- Review GitHub workflows

## Checklist

- [x] My contribution is either my original work, or comes from projects with an MIT-compatible license, in which case I have updated the THIRD-PARTY-NOTICES file accordingly
- [x] I have added and/or updated related documentation (if applicable)
- [x] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/master/CHANGELOG.md) according to the modifications I made

## Other information
