### PR TITLE
Fix yellow triangle on dependencies in VS2019 v16.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes to existing features
 
+- Warning NU1604 is no longer suppressed on dependencies automatically introduced in projects by Buildvana SDK. Suppressing the warning prevented a yellow triangle from appearing near the affected packages in Visual Studio 2019 until version 16.7; in version 16.11, on the contrary, the yellow triangle appears if the warning _is_ suppressed.
+
 ### Bugs fixed in this release
 
 ### Known problems introduced by this release

--- a/src/Buildvana.Sdk/Sdk/Sdk.targets
+++ b/src/Buildvana.Sdk/Sdk/Sdk.targets
@@ -85,11 +85,9 @@
     <!--
       Transform BV_PackageReference items into PackageReference items.
       No need for PackageVersion items because our packages are defined implicitly.
-      The NoWarn metadata prevents a yellow triangle to appear on each of our packages in the project tree in VS2019 (tested on v16.7.3).
     -->
     <PackageReference Include="@(BV_PackageReference)"
-                      IsImplicitlyDefined="true"
-                      NoWarn="NU1604" />
+                      IsImplicitlyDefined="true" />
 
   </ItemGroup>
 


### PR DESCRIPTION
## Types of changes

- [x] Bugfix
- [ ] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [ ] Dependencies added, updated, or removed
- [ ] Build related changes
- [ ] Repository infrastructure changes (e.g. changes to issue / PR templates)
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other (please describe below)

## Proposed changes / fixed issues

Do not suppress warning NU1604 on dependencies introduced by the SDK.

The warning suppression prevented a yellow triangle from appearing next to affecteddependencies in versions of Visual Studio 2019 up to and including 16.7. In version 16.11, however, the situation is reversed: now yellow triangles appear if the warning is suppressed, and do not appear if it is not.

## Checklist

- [x] My contribution is my original work
- [ ] My contribution, or part of it, comes from projects with an MIT-compatible license AND I have updated the THIRD-PARTY-NOTICES file accordingly
- [ ] I have added and/or updated related documentation (if applicable)
- [x] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/main/CHANGELOG.md) according to the modifications I made
