### PR TITLE
Alternate Pack target for executable projects

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,6 +26,11 @@ jobs:
       with:
         fetch-depth: 0 # Nerdbank.GitVersioning needs a deep clone, as it needs access to Git history.
 
+    - name: Setup .NET 5.0 # Needed for ExportAnnotations
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 5.0.x
+
     - name: Setup .NET 6.0
       uses: actions/setup-dotnet@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes to existing features
 
-- **POTENTIALLY BREAKING CHANGE:** The minimum supported MSBuild version is now 17.0 (.NET SDK 6.0, Visual Studio 2022 v17.0). As a consequence, the only supported .NET environments are .NET 6.0 or newer and .NET Framework 4.7.2 or newer. This of course refers to the build phase; you can use Buildvana SDK to target older versions of .NET, .NET Core, or .NET Framework.
-- **BREAKING CHANGE:** The `AllowUnderscoresInMemberNames` property is no longer supported. Just append `;CA1707` to the `NoWarn` property instead.
+- https://github.com/Buildvana/Buildvana.Sdk/pull/123 - **POTENTIALLY BREAKING CHANGE:** The minimum supported MSBuild version is now 17.0 (.NET SDK 6.0, Visual Studio 2022 v17.0). As a consequence, the only supported .NET environments are .NET 6.0 or newer and .NET Framework 4.7.2 or newer. This of course refers to the build phase; you can use Buildvana SDK to target older versions of .NET, .NET Core, or .NET Framework.
+- https://github.com/Buildvana/Buildvana.Sdk/pull/123 - **BREAKING CHANGE:** The `AllowUnderscoresInMemberNames` property is no longer supported. Just append `;CA1707` to the `NoWarn` property instead.
 
 ### Bugs fixed in this release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+- https://github.com/Buildvana/Buildvana.Sdk/pull/124 - When the new `UseAlternatePack` property is set to `true`, Buildvana SDK hijacks the Pack target to publish a project to one or more folders and/or create a setup executable using InnoSetup.
+
 ### Changes to existing features
 
 - https://github.com/Buildvana/Buildvana.Sdk/pull/123 - **POTENTIALLY BREAKING CHANGE:** The minimum supported MSBuild version is now 17.0 (.NET SDK 6.0, Visual Studio 2022 v17.0). As a consequence, the only supported .NET environments are .NET 6.0 or newer and .NET Framework 4.7.2 or newer. This of course refers to the build phase; you can use Buildvana SDK to target older versions of .NET, .NET Core, or .NET Framework.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes to existing features
 
 - **POTENTIALLY BREAKING CHANGE:** The minimum supported MSBuild version is now 17.0 (.NET SDK 6.0, Visual Studio 2022 v17.0). As a consequence, the only supported .NET environments are .NET 6.0 or newer and .NET Framework 4.7.2 or newer. This of course refers to the build phase; you can use Buildvana SDK to target older versions of .NET, .NET Core, or .NET Framework.
+- **BREAKING CHANGE:** The `AllowUnderscoresInMemberNames` property is no longer supported. Just append `;CA1707` to the `NoWarn` property instead.
 
 ### Bugs fixed in this release
 

--- a/src/Buildvana.Sdk/Modules/AlternatePack/Module.Core.targets
+++ b/src/Buildvana.Sdk/Modules/AlternatePack/Module.Core.targets
@@ -81,7 +81,7 @@
       <AppFullName Condition="'$(AppFullName)' == ''">$(AppShortName)</AppFullName>
       <AppCopyright Condition="'$(AppCopyright)' == ''">$(Copyright)</AppCopyright>
       <AppDescription Condition="'$(AppDescription)' == ''">$(Description)</AppDescription>
-      <AppMinWindowsVersion Condition="'$(AppMinWindowsVersion)' == ''">10.0.10240</AppMinWindowsVersion> <!-- Default to Windows 10 only -->
+      <AppMinWindowsVersion Condition="'$(AppMinWindowsVersion)' == ''">10.0.10240</AppMinWindowsVersion> <!-- Default to Windows 10 / 11 only -->
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Buildvana.Sdk/Modules/AlternatePack/Module.Core.targets
+++ b/src/Buildvana.Sdk/Modules/AlternatePack/Module.Core.targets
@@ -1,0 +1,186 @@
+<Project>
+
+  <!-- Redefine Pack target-->
+
+  <PropertyGroup>
+    <ImportNuGetBuildTasksPackTargetsFromSdk>false</ImportNuGetBuildTasksPackTargetsFromSdk>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <IsInnerBuild Condition="'$(TargetFramework)' != '' AND '$(TargetFrameworks)' != ''">true</IsInnerBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackDependsOn>$(BeforePack);$(PackDependsOn)</PackDependsOn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectCapability Include="Pack" />
+  </ItemGroup>
+
+  <Target Name="Pack"
+          DependsOnTargets="$(PackDependsOn)" />
+
+  <!-- Xcopy deployment (also used by setup generation)  -->
+
+  <Target Name="CompletePublishFolderMetadata">
+
+    <ItemGroup>
+      <PublishFolder Update="%(PublishFolder.Identity)"
+                     Condition="'%(PublishFolder.SetupIncludeFile)' == ''"
+                     InnoSetupIncludePath="$(BaseIntermediateOutputPath)$(Configuration)\%(PublishFolder.Identity).iss" />
+      <PublishFolder Update="%(PublishFolder.Identity)"
+                     Condition="'%(PublishFolder.PublishDir)' == ''"
+                     PublishDir="$(ArtifactsDirectory)$(Configuration)\$(MSBuildProjectName)\%(PublishFolder.Identity)\" />
+      <PublishFolder Update="%(PublishFolder.Identity)"
+                     Condition="'%(PublishFolder.Temporary)' != 'true'"
+                     Temporary="false" />
+    </ItemGroup>
+
+  </Target>
+
+  <PropertyGroup>
+    <PackDependsOn>$(PackDependsOn);PublishInPublishFolders</PackDependsOn>
+  </PropertyGroup>
+
+  <Target Name="PublishInPublishFolders"
+          DependsOnTargets="CompletePublishFolderMetadata"
+          Condition="@(PublishFolder->Count()) > 0">
+
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="Publish"
+             Properties="PublishingFolder=%(PublishFolder.Identity);
+                         PublishProtocol=FileSystem;
+                         PublishDir=%(PublishFolder.PublishDir);
+                         TargetFramework=%(PublishFolder.TargetFramework);
+                         RuntimeIdentifier=%(PublishFolder.RuntimeIdentifier);
+                         %(PublishFolder.Properties)" />
+
+  </Target>
+
+  <Target Name="RemoveTemporaryPublishFolders"
+          AfterTargets="Pack"
+          DependsOnTargets="CompletePublishFolderMetadata"
+          Condition="@(PublishFolder->Count()) > 0">
+
+    <RemoveDir Directories="%(PublishFolder.PublishDir)"
+               Condition="'%(PublishFolder.Temporary)' == 'true'" />
+
+  </Target>
+
+  <Target Name="GenerateSetupIncludeFile"
+          AfterTargets="Publish"
+          DependsOnTargets="CompletePublishFolderMetadata"
+          Condition="'$(PublishingFolder)' != ''">
+
+    <PropertyGroup>
+      <CompanyShortName Condition="'$(CompanyShortName)' == ''">$(Company)</CompanyShortName>
+      <CompanyFullName Condition="'$(CompanyFullName)' == ''">$(Company)</CompanyFullName>
+      <AppShortName Condition="'$(AppShortName)' == ''">$(AssemblyName)</AppShortName>
+      <AppFullName Condition="'$(AppFullName)' == ''">$(Title)</AppFullName>
+      <AppFullName Condition="'$(AppFullName)' == ''">$(AppShortName)</AppFullName>
+      <AppCopyright Condition="'$(AppCopyright)' == ''">$(Copyright)</AppCopyright>
+      <AppDescription Condition="'$(AppDescription)' == ''">$(Description)</AppDescription>
+      <AppMinWindowsVersion Condition="'$(AppMinWindowsVersion)' == ''">10.0.10240</AppMinWindowsVersion> <!-- Default to Windows 10 only -->
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <InnoSetupIncludePath Condition="'%(PublishFolder.Identity)' == '$(PublishingFolder)'">%(PublishFolder.InnoSetupIncludePath)</InnoSetupIncludePath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <InnoSetupConstant Include="COMPANY_SHORTNAME" Value="$(CompanyShortName)" />
+      <InnoSetupConstant Include="COMPANY_FULLNAME" Value="$(CompanyFullName)" />
+      <InnoSetupConstant Include="COMPANY_WEBSITE" Value="$(CompanyWebSite)" />
+      <InnoSetupConstant Include="COMPANY_SUPPORTPHONE" Value="$(CompanySupportPhone)" />
+      <InnoSetupConstant Include="APP_EXENAME" Value="$(AssemblyName)" />
+      <InnoSetupConstant Include="APP_SHORTNAME" Value="$(AssemblyName)" />
+      <InnoSetupConstant Include="APP_FULLNAME" Value="$(AssemblyName)" />
+      <InnoSetupConstant Include="APP_COMMENTS" Value="$(AppComments)" />
+      <InnoSetupConstant Include="APP_CONTACT" Value="$(AppContact)" />
+      <InnoSetupConstant Include="APP_COPYRIGHT" Value="$(AppCopyright)" />
+      <InnoSetupConstant Include="APP_DESCRIPTION" Value="$(AppDescription)" />
+      <InnoSetupConstant Include="APP_VERSION" Value="$(VersionPrefix)" />
+      <InnoSetupConstant Include="APP_SEMANTIC_VERSION" Value="$(AssemblyInformationalVersion)" />
+      <InnoSetupConstant Include="APP_MINWINDOWSVERSION" Value="$(AppMinWindowsVersion)" />
+      <InnoSetupConstant Include="SOURCE_DIR" Value="$(PublishDir)" />
+      <InnoSetupConstant Include="SETUP_DIR" Value="$(ArtifactsDirectory)$(Configuration)\$(MSBuildProjectName)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <InnoSetupIncludeLine Include="#define %(InnoSetupConstant.Identity) '$([System.String]::new(&quot;%(InnoSetupConstant.Value)&quot;).Replace(&quot;'&quot;, &quot;''&quot;))'" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(InnoSetupIncludePath)"
+                      Lines="@(InnoSetupIncludeLine)"
+                      Overwrite="true" />
+
+    <ItemGroup>
+      <InnoSetupIncludeLines Remove="@(InnoSetupIncludeLines)" />
+    </ItemGroup>
+
+  </Target>
+
+  <!-- Generate setup -->
+
+  <ItemGroup>
+    <PackageReference Include="Tools.InnoSetup"
+                      IncludeAssets="build"
+                      ExcludeAssets="runtime"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
+  <Target Name="CompleteInnoSetupScriptMetadata"
+          DependsOnTargets="CompletePublishFolderMetadata">
+
+    <CreateItem Include="@(InnoSetupScript)"
+                AdditionalMetadata="PFIdentity=%(PublishFolder.Identity);
+                                    TargetFramework=%(PublishFolder.TargetFramework);
+                                    SourceDir=%(PublishFolder.PublishDir);
+                                    IncludePath=$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', '%(PublishFolder.InnoSetupIncludePath)'))">
+      <Output ItemName="_Temp" TaskParameter="Include" />
+    </CreateItem>
+
+    <ItemGroup>
+      <_Temp Remove="%(_Temp.Identity)"
+             Condition="'%(_Temp.PFIdentity)' != '%(_Temp.UsePublishFolder)'" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <InnoSetupScript Remove="@(InnoSetupScript)" />
+      <InnoSetupScript Include="@(_Temp)"
+                       RemoveMetadata="PFIdentity" />
+      <_Temp Remove="@(_Temp)" />
+    </ItemGroup>
+
+  </Target>
+
+  <PropertyGroup>
+    <PackDependsOn>$(PackDependsOn);ProcessInnoSetupScripts</PackDependsOn>
+  </PropertyGroup>
+
+  <Target Name="ProcessInnoSetupScripts"
+          DependsOnTargets="PublishInPublishFolders;CompleteInnoSetupScriptMetadata"
+          Condition="@(InnoSetupScript->Count()) > 0">
+
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="GenerateSetup"
+             Properties="TargetFramework=%(InnoSetupScript.TargetFramework);
+                         InnoSetupScriptFullPath=%(InnoSetupScript.FullPath);
+                         InnoSetupIncludePath=%(InnoSetupScript.IncludePath)" />
+
+  </Target>
+
+  <Target Name="GenerateSetup">
+
+    <PropertyGroup>
+      <InnoSetupCommandLine>&quot;$(InnoSetupCompiler)&quot; &quot;/J$(InnoSetupIncludePath)&quot; &quot;$(InnoSetupScriptFullPath)&quot;</InnoSetupCommandLine>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="&gt;&gt;&gt;&gt;$(InnoSetupCommandLine)&lt;&lt;&lt;&lt;" />
+
+    <Exec Command="$(InnoSetupCommandLine)" />
+
+  </Target>
+
+</Project>

--- a/src/Buildvana.Sdk/Modules/AlternatePack/Module.targets
+++ b/src/Buildvana.Sdk/Modules/AlternatePack/Module.targets
@@ -1,0 +1,6 @@
+<Project>
+
+  <Import Project="Module.Core.targets"
+          Condition="'$(UseAlternatePack)' == 'true'" />
+
+</Project>

--- a/src/Buildvana.Sdk/Sdk/PackageVersions.props
+++ b/src/Buildvana.Sdk/Sdk/PackageVersions.props
@@ -12,6 +12,7 @@
     <BV_PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <BV_PackageVersion Include="ReSharper.ExportAnnotations.Task" Version="1.3.2" />
     <BV_PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.406" />
+    <BV_PackageVersion Include="Tools.InnoSetup" Version="6.2.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Common.props
+++ b/test/Common.props
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <Packable>false</Packable>
-    <NoWarn>CA1707;SA1201;SA1202;SA1203;SA1204;SA1600</NoWarn>
+    <NoWarn>CA1707;SA1201;SA1202;SA1203;SA1204;SA1600;$(NoWarn)</NoWarn>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix
- [x] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [x] Dependencies added, updated, or removed
- [ ] Build related changes
- [ ] Repository infrastructure changes (e.g. changes to issue / PR templates)
- [x] CI related changes
- [ ] Documentation update
- [ ] Other (please describe below)

## Proposed changes / fixed issues

When you set the `UseAlternatePack` property to `true`, Buildvana SDK hijacks the Pack target to do the following:

- publish to one or more folders;
- optionally create a setup program with InnoSetup[^1].

### Publishing to one or more folders

Example project file `HelloWorld.csproj`:

```XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <Title>HelloWorld</Title>
    <Description>The improved, more modern "Hello World!" program no one has asked for.</Description>
    <TargetFrameworks>net6.0-windows</TargetFrameworks>
    <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
    <OutputType>Exe</OutputType>
    <UseAlternatePack>true</UseAlternatePack>
  </PropertyGroup>

  <ItemGroup>
    <None Include="$(HomeDirectory)LICENSE" Link="LICENSE" CopyToOutputDirectory="Always" />
    <None Include="$(HomeDirectory)THIRD-PARTY-NOTICES" Link="THIRD-PARTY-NOTICES" CopyToOutputDirectory="Always" />
  </ItemGroup>

  <ItemGroup>
    <!-- This will invoke the Publish target from the Pack target.
         You can have as many PublishFolder items as you want.
    -->
    <PublishFolder Include="Dist-x86"
                   TargetFramework="net6.0-windows"
                   RuntimeIdentifier="win-x86"
                   Properties="SelfContained=true;
                               PublishReadyToRun=true;
                               PublishTrimmed=true;
                               TrimMode=CopyUsed;
                               PublishSingleFile=true;
                               DeleteExistingFiles=true;
                               ExcludeGeneratedDebugSymbols=true" />
    <PublishFolder Include="Dist-x64"
                   TargetFramework="net6.0-windows"
                   RuntimeIdentifier="win-x64"
                   Properties="SelfContained=true;
                               PublishReadyToRun=true;
                               PublishTrimmed=true;
                               TrimMode=CopyUsed;
                               PublishSingleFile=true;
                               DeleteExistingFiles=true;
                               ExcludeGeneratedDebugSymbols=true" />
  </ItemGroup>

</Project>
```

The published files will be in the `$(ArtifactsDirectory)\$(Configuration)\HelloWorld\Dist-x86` and `$(ArtifactsDirectory)\$(Configuration)\HelloWorld\Dist-x64` folders.

### Using InnoSetup

Example project file `HelloWorld.csproj`:

```XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <Title>HelloWorld</Title>
    <Description>The improved, more modern "Hello World!" program no one has asked for.</Description>
    <TargetFrameworks>net6.0-windows</TargetFrameworks>
    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
    <OutputType>Exe</OutputType>
    <UseAlternatePack>true</UseAlternatePack>
  </PropertyGroup>

  <ItemGroup>
    <None Include="$(HomeDirectory)LICENSE" Link="LICENSE" CopyToOutputDirectory="Always" />
    <None Include="$(HomeDirectory)THIRD-PARTY-NOTICES" Link="THIRD-PARTY-NOTICES" CopyToOutputDirectory="Always" />
  </ItemGroup>

  <ItemGroup>
    <!-- Temporary means that the folder will be deleted at the end of the Pack target execution. -->
    <PublishFolder Include="SetupFiles"
                   Temporary="true"
                   TargetFramework="net6.0-windows"
                   RuntimeIdentifier="win-x64"
                   Properties="SelfContained=true;
                               PublishReadyToRun=true;
                               PublishTrimmed=true;
                               TrimMode=CopyUsed;
                               PublishSingleFile=true;
                               DeleteExistingFiles=true;
                               ExcludeGeneratedDebugSymbols=true" />
  </ItemGroup>

  <ItemGroup>
    <InnoSetupScript Include="Setup.iss" UsePublishFolder="SetupFiles" />
  </ItemGroup>

</Project>
```

The Pack target will:
- publish the application in `$(ArtifactsDirectory)\$(Configuration)\HelloWorld\SetupFiles`;
- create a temporary include file for InnoSetup, containing several useful constants (more info below);
- invoke InnoSetup to execute `Setup.iss` (located, by default, in the same folder as the project file);
- delete the `SetupFiles` folder, because the `PublishFolder` tag has the `Temporary` attribute.

Note that you do not need InnoSetup installed on your development machine (or CI server). Buildvana SDK will automatically reference the [`Tools.InnoSetup` NuGet package](https://github.com/vslavik/nuget-tools-innosetup). Of course you have to build on a Windows system, as the InnoSetup compiler is a Windows executable.

### Passing constants to InnoSetup

To integrate the InnoSetup compiler even better in your build process, you can define constants for InnoSetup from your project files. Just add to `InnoSetupConstant` items:

```XML
<ItemGroup>
  <InnoSetupConstant Include="MY_CONSTANT" Value="My value" />
</ItemGroup>
```

Some constants are already defined for you. The following table lists them together with their values.

| Constant name         | Value                                                         |
| --------------------- | ------------------------------------------------------------- |
| SOURCE_DIR            | Full path of the publish folder                               |
| SETUP_DIR             | `$(ArtifactsDirectory)$(Configuration)\$(MSBuildProjectName)` |
| COMPANY_SHORTNAME     | `$(CompanyShortName)`                                         |
| COMPANY_FULLNAME      | `$(CompanyFullName)`                                          |
| COMPANY_WEBSITE       | `$(CompanyWebSite)`                                           |
| COMPANY_SUPPORTPHONE  | `$(CompanySupportPhone)`                                      |
| APP_EXENAME           | `$(AssemblyName)`                                             |
| APP_SHORTNAME         | `$(AssemblyName)`                                             |
| APP_FULLNAME          | `$(AssemblyName)`                                             |
| APP_COMMENTS          | `$(AppComments)`                                              |
| APP_CONTACT           | `$(AppContact)`                                               |
| APP_COPYRIGHT         | `$(AppCopyright)`                                             |
| APP_DESCRIPTION       | `$(AppDescription)`                                           |
| APP_VERSION           | `$(VersionPrefix)`                                            |
| APP_SEMANTIC_VERSION  | `$(AssemblyInformationalVersion)`                             |
| APP_MINWINDOWSVERSION | `$(AppMinWindowsVersion)`                                     |

Some of the MSBuild constants mentioned above are already well-kwown (`AssemblyName`, `Company`, etc.) The others are specific to InnoSetup integration and can be set in your project file or in a `Common.props` file. When not set, they will respectively take the following default values:

| Constant name          | Value                                                         |
| ---------------------- | ------------------------------------------------------------- |
| `CompanyShortName`     | `$(Company)`                                                  |
| `CompanyFullName`      | `$(Company)`                                                  |
| `AppShortName`         | `$(AssemblyName)`                                             |
| `AppFullName`          | `$(Title)` or, if `Title` is empty, `$(AppShortName)`         |
| `AppCopyright`         | `$(Copyright)`                                                |
| `AppDescription`       | `$(Description)`                                              |
| `AppMinWindowsVersion` | `10.0.10240`                                                  |

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
If you're unsure about any of the following items, don't hesitate to ask. We're here to help!
-->

- [x] My contribution is my original work
- [ ] My contribution, or part of it, comes from projects with an MIT-compatible license AND I have updated the THIRD-PARTY-NOTICES file accordingly
- [ ] I have added and/or updated related documentation (if applicable)
- [x] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/main/CHANGELOG.md) according to the modifications I made

[^1]: [InnoSetup](https://jrsoftware.org/isinfo.php) is, by far, the best setup creator for Windows. If you write software for Windows and don't know InnoSetup, you definitely should give it a try. It's open source, free to use even for commercial applications, and puts any other program in its category to shame.  
InnoSetup is Copyright (C) 1997-2022 Jordan Russell. Portions Copyright (C) 2000-2022 Martijn Laan. The information presented in this post do not imply endorsment of Buildvana SDK by InnoSetup authors.