### PR TITLE
[FIX] Package Tools.InnoSetup is not referenced correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugs fixed in this release
 
+- https://github.com/Buildvana/Buildvana.Sdk/pull/130 - InnoSetup integration has been fixed.
+
 ### Known problems introduced by this release
 
 ## [1.0.0-alpha.16](https://github.com/Buildvana/Buildvana.Sdk/releases/tag/1.0.0-alpha.16) (2022-04-01)

--- a/src/Buildvana.Sdk/Modules/AlternatePack/Module.Core.targets
+++ b/src/Buildvana.Sdk/Modules/AlternatePack/Module.Core.targets
@@ -124,10 +124,10 @@
   <!-- Generate setup -->
 
   <ItemGroup>
-    <PackageReference Include="Tools.InnoSetup"
-                      IncludeAssets="build"
-                      ExcludeAssets="runtime"
-                      PrivateAssets="all" />
+    <BV_PackageReference Include="Tools.InnoSetup"
+                         IncludeAssets="build"
+                         ExcludeAssets="runtime"
+                         PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="CompleteInnoSetupScriptMetadata"


### PR DESCRIPTION
## Types of changes

- [x] Bugfix
- [ ] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [ ] Dependencies added, updated, or removed
- [ ] Build related changes
- [ ] Repository infrastructure changes (e.g. changes to issue / PR templates)
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other (please describe below)

## Proposed changes / fixed issues

Package `Tools.InnoSetup` is referenced via a `PackageReference` in v1.0.0-alpha.15 and v1.0.0-alpha.16. This is not correct: package references generated by Buildvana SDK must be specified with `BV_PackageReference` items.

This PR fixes InnoSetup integration by changing the `PackageReference` item referencing `Tools.InnoSetup` to a `BV_PackageReference` item.

## Checklist

- [x] My contribution is my original work
- [ ] My contribution, or part of it, comes from projects with an MIT-compatible license AND I have updated the THIRD-PARTY-NOTICES file accordingly
- [ ] I have added and/or updated related documentation (if applicable)
- [ ] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/main/CHANGELOG.md) according to the modifications I made
