### PR TITLE
Fix typo in Polyfills module forcing UsePolyfills property to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugs fixed in this release
 
+- https://github.com/Buildvana/Buildvana.Sdk/pull/138 - The `UsePolyfills` property was forced to `true` in all projects in version 1.0.0-aplha.18.
+
 ### Known problems introduced by this release
 
 ## [1.0.0-alpha.18](https://github.com/Buildvana/Buildvana.Sdk/releases/tag/1.0.0-alpha.18) (2022-04-26)

--- a/src/Buildvana.Sdk/Modules/Polyfills/Module.targets
+++ b/src/Buildvana.Sdk/Modules/Polyfills/Module.targets
@@ -2,7 +2,7 @@
 
   <!-- Coalesce UsePolyfills to a boolean value, defaulting to true; force to false for non-C# projects. -->
   <PropertyGroup>
-    <UsePolyfills> Condition="'$(MSBuildProjectExtension)' != '.csproj'">false</UsePolyfills>
+    <UsePolyfills Condition="'$(MSBuildProjectExtension)' != '.csproj'">false</UsePolyfills>
     <UsePolyfills Condition="'$(UsePolyfills)' != 'false'">true</UsePolyfills>
   </PropertyGroup>
 


### PR DESCRIPTION
## Types of changes

- [x] Bugfix
- [ ] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [ ] Dependencies added, updated, or removed
- [ ] Build related changes
- [ ] Repository infrastructure changes (e.g. changes to issue / PR templates)
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other (please describe below)

## Proposed changes / fixed issues

- Version 1.0.0-alpha.18 contains a typo in the Polyfills module that forces the `UsePolyfills` property to `true` in all projects.

## Checklist

- [x] My contribution is my original work
- [ ] My contribution, or part of it, comes from projects with an MIT-compatible license AND I have updated the THIRD-PARTY-NOTICES file accordingly
- [ ] I have added and/or updated related documentation (if applicable)
- [x] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/main/CHANGELOG.md) according to the modifications I made
