### PR TITLE
Add support for README file in NuGet packages

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "jetbrains.resharper.globaltools": {
-      "version": "2022.1.0",
+      "version": "2022.1.1",
       "commands": [
         "jb"
       ]

--- a/Buildvana.Sdk.sln
+++ b/Buildvana.Sdk.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "- Configuration", "- Config
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props
+		global.json = global.json
 		stylecop.json = stylecop.json
 		VERSION = VERSION
 	EndProjectSection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### New features
 
+- https://github.com/Buildvana/Buildvana.Sdk/pull/142 - For packable projects, Buildvana SDK will automatically find a README.md file and include it in the NuGet package. To disable this feature, set the `ReadmeFileInPackage` property to `false`.  
+Recognized names for the README file, in order of lookup, are: `Package-README.md`; `package-readme.md`; `NuGet-README.md`; `nuget-readme.md`; `NuGet.md`; `nuget.md`; `README.md`; `readme.md`.
 ### Changes to existing features
 
 ### Bugs fixed in this release

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.2.0"/>
   </ItemGroup>
 
 </Project>

--- a/docs/ErrorsAndWarnings.md
+++ b/docs/ErrorsAndWarnings.md
@@ -92,6 +92,9 @@ Each module, as well as the SDK itself, is assigned a contiguous range of 100 er
 | BVE1506 | Specified package icon file '...' does not exist. | A package icon file specified by the `PackageIconPath` property does not exist. |
 | BVE1507 | Specified package icon file '...' was not found. | A package icon file specified by the `PackageIcon` property was not found in the project's directory nor in any containing directory. |
 | BVE1508 | No package icon file found. | No package icon file was specified, and no default package icon has been found. Set the `IconInPackage` property to `false` to explicitly exclude any package icon to be included in the package. |
+| BVE1509 | Specified README file '...' does not exist. | A README file specified by the `PackageReadmePath` property does not exist. |
+| BVE1510 | Specified README file '...' was not found. | A README file specified by the `PackageReadmeFile` property was not found in the project's directory nor in any containing directory. |
+| BVE1511 | No README file found for package. | No README file was specified, and no default README file has been found. Set the `ReadmeFileInPackage` property to `false` to explicitly exclude any README file to be included in the package. |
 
 | Warning code | Message | Description |
 | ------------ | ------- | ----------- |

--- a/global.json
+++ b/global.json
@@ -6,5 +6,5 @@
   },
   "msbuild-sdks": {
     "Buildvana.Sdk": "1.0.0-alpha.19",
-    "Microsoft.Build.NoTargets": "3.3.0"
+    "Microsoft.Build.NoTargets": "3.4.0"
 }}

--- a/src/Buildvana.Sdk.CodeGeneration/Configuration/AssemblyAttributeFragment.cs
+++ b/src/Buildvana.Sdk.CodeGeneration/Configuration/AssemblyAttributeFragment.cs
@@ -12,11 +12,9 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace Buildvana.Sdk.CodeGeneration.Configuration;
-#pragma warning disable CA1711 // Rename type so that it does not end in 'Attribute' - Does anyone have a better name for this type?
-public sealed class AssemblyAttribute : CodeFragment
-#pragma warning restore CA1711
+public sealed class AssemblyAttributeFragment : CodeFragment
 {
-    public AssemblyAttribute(
+    public AssemblyAttributeFragment(
         string type,
         IEnumerable<OrderedParameter> orderedParameters,
         IEnumerable<NamedParameter>? namedParameters = null)

--- a/src/Buildvana.Sdk.CodeGeneration/Configuration/ThisAssemblyClassFragment.cs
+++ b/src/Buildvana.Sdk.CodeGeneration/Configuration/ThisAssemblyClassFragment.cs
@@ -12,9 +12,9 @@ using System.Linq;
 
 namespace Buildvana.Sdk.CodeGeneration.Configuration;
 
-public sealed class ThisAssemblyClass : CodeFragment
+public sealed class ThisAssemblyClassFragment : CodeFragment
 {
-    public ThisAssemblyClass(
+    public ThisAssemblyClassFragment(
         string? @namespace,
         string name,
         IEnumerable<Constant> constants)

--- a/src/Buildvana.Sdk.CodeGeneration/Internal/CSharpCodeGenerator.cs
+++ b/src/Buildvana.Sdk.CodeGeneration/Internal/CSharpCodeGenerator.cs
@@ -24,14 +24,14 @@ internal sealed class CSharpCodeGenerator : CodeGenerator<CSharpSyntaxNode>
     protected override SyntaxTrivia GenerateLineComment(string comment)
         => Comment("// " + comment);
 
-    protected override CSharpSyntaxNode GenerateAssemblyAttribute(AssemblyAttribute assemblyAttribute)
+    protected override CSharpSyntaxNode GenerateAssemblyAttribute(AssemblyAttributeFragment assemblyAttribute)
         => BuildAttribute(
             SyntaxKind.AssemblyKeyword,
             assemblyAttribute.Type,
             assemblyAttribute.OrderedParameters.Select(p => p.Value),
             assemblyAttribute.NamedParameters.Select(p => (p.Name, p.Value)));
 
-    protected override CSharpSyntaxNode GenerateThisAssemblyClass(ThisAssemblyClass thisAssemblyClass)
+    protected override CSharpSyntaxNode GenerateThisAssemblyClass(ThisAssemblyClassFragment thisAssemblyClass)
     {
         var classDeclaration = ClassDeclaration(thisAssemblyClass.Name)
             .AddModifiers(

--- a/src/Buildvana.Sdk.CodeGeneration/Internal/CodeGenerator`1.cs
+++ b/src/Buildvana.Sdk.CodeGeneration/Internal/CodeGenerator`1.cs
@@ -36,16 +36,16 @@ internal abstract class CodeGenerator<TSyntaxNode> : CodeGenerator
 
     protected abstract SyntaxTrivia GenerateLineComment(string comment);
 
-    protected abstract TSyntaxNode GenerateAssemblyAttribute(AssemblyAttribute assemblyAttribute);
+    protected abstract TSyntaxNode GenerateAssemblyAttribute(AssemblyAttributeFragment assemblyAttribute);
 
-    protected abstract TSyntaxNode GenerateThisAssemblyClass(ThisAssemblyClass thisAssemblyClass);
+    protected abstract TSyntaxNode GenerateThisAssemblyClass(ThisAssemblyClassFragment thisAssemblyClass);
 
     protected abstract TSyntaxNode GenerateCompilationUnit(IEnumerable<TSyntaxNode> syntaxNodes);
 
     private TSyntaxNode GenerateCodeFragment(CodeFragment? fragment)
         => fragment switch {
-            AssemblyAttribute assemblyAttribute => GenerateAssemblyAttribute(assemblyAttribute),
-            ThisAssemblyClass thisAssemblyClass => GenerateThisAssemblyClass(thisAssemblyClass),
+            AssemblyAttributeFragment assemblyAttribute => GenerateAssemblyAttribute(assemblyAttribute),
+            ThisAssemblyClassFragment thisAssemblyClass => GenerateThisAssemblyClass(thisAssemblyClass),
             null => throw new ArgumentNullException(nameof(fragment)),
             _ => throw new ArgumentException($"Unknown code fragment class '{fragment.GetType().Name}' passed to {nameof(GenerateCodeFragment)}.", nameof(fragment)),
         };

--- a/src/Buildvana.Sdk.CodeGeneration/Internal/VisualBasicCodeGenerator.cs
+++ b/src/Buildvana.Sdk.CodeGeneration/Internal/VisualBasicCodeGenerator.cs
@@ -24,14 +24,14 @@ internal sealed class VisualBasicCodeGenerator : CodeGenerator<VisualBasicSyntax
     protected override SyntaxTrivia GenerateLineComment(string comment)
         => CommentTrivia("' " + comment);
 
-    protected override VisualBasicSyntaxNode GenerateAssemblyAttribute(AssemblyAttribute assemblyAttribute)
+    protected override VisualBasicSyntaxNode GenerateAssemblyAttribute(AssemblyAttributeFragment assemblyAttribute)
         => BuildAttribute(
             SyntaxKind.AssemblyKeyword,
             assemblyAttribute.Type,
             assemblyAttribute.OrderedParameters.Select(p => p.Value),
             assemblyAttribute.NamedParameters.Select(p => (p.Name, p.Value)));
 
-    protected override VisualBasicSyntaxNode GenerateThisAssemblyClass(ThisAssemblyClass thisAssemblyClass)
+    protected override VisualBasicSyntaxNode GenerateThisAssemblyClass(ThisAssemblyClassFragment thisAssemblyClass)
     {
         var moduleBlock = ModuleBlock(
                 ModuleStatement(thisAssemblyClass.Name)

--- a/src/Buildvana.Sdk.Tasks/WriteLiteralAssemblyAttributes.cs
+++ b/src/Buildvana.Sdk.Tasks/WriteLiteralAssemblyAttributes.cs
@@ -29,7 +29,7 @@ public sealed class WriteLiteralAssemblyAttributes : BuildvanaSdkCodeGeneratorTa
     protected override IEnumerable<CodeFragment> GetCodeFragments()
         => (LiteralAssemblyAttributes ?? Enumerable.Empty<ITaskItem>()).Select(ExtractAttributeFromItem);
 
-    private static AssemblyAttribute ExtractAttributeFromItem(ITaskItem item)
+    private static AssemblyAttributeFragment ExtractAttributeFromItem(ITaskItem item)
     {
         var type = item.ItemSpec;
 
@@ -102,7 +102,7 @@ public sealed class WriteLiteralAssemblyAttributes : BuildvanaSdkCodeGeneratorTa
             }
         }
 
-        return new AssemblyAttribute(
+        return new AssemblyAttributeFragment(
             type,
             orderedParameters.Select(p => new OrderedParameter(p)),
             namedParameters.Select(p => new NamedParameter(p.Key, p.Value)));

--- a/src/Buildvana.Sdk.Tasks/WriteThisAssemblyClass.cs
+++ b/src/Buildvana.Sdk.Tasks/WriteThisAssemblyClass.cs
@@ -36,7 +36,7 @@ public sealed class WriteThisAssemblyClass : BuildvanaSdkCodeGeneratorTask
         var classNamespace = StringUtility.IsNullOrEmpty(Namespace) ? null : Namespace;
         var className = StringUtility.IsNullOrEmpty(ClassName) ? "ThisAssembly" : ClassName;
         var constants = (Constants ?? Enumerable.Empty<ITaskItem>()).Select(ExtractConstantDefinitionFromItem);
-        var fragment = new ThisAssemblyClass(classNamespace, className, constants);
+        var fragment = new ThisAssemblyClassFragment(classNamespace, className, constants);
         yield return fragment;
     }
 

--- a/src/Buildvana.Sdk/Modules/NuGetPack/Module.Core.targets
+++ b/src/Buildvana.Sdk/Modules/NuGetPack/Module.Core.targets
@@ -7,12 +7,17 @@
     <Owners Condition="'$(Owners)' == ''">$(Authors)</Owners>
   </PropertyGroup>
 
+  <Import Project="Readme.targets" />
   <Import Project="License.targets" />
   <Import Project="ThirdPartyNotices.targets" />
   <Import Project="PackageIcon.targets" />
 
   <Target Name="BV_ShowFilesUsedInPackage"
           AfterTargets="BeforePack">
+
+    <Message Importance="High"
+             Condition="'$(PackageReadmePath)' != '' And '$(PackageReadmeFile)' != ''"
+             Text="Using '$(PackageReadmePath)' as README file in package '$(PackageId)'." />
 
     <Message Importance="High"
              Condition="'$(PackageLicensePath)' != '' And '$(PackageLicenseFile)' != ''"

--- a/src/Buildvana.Sdk/Modules/NuGetPack/Readme.targets
+++ b/src/Buildvana.Sdk/Modules/NuGetPack/Readme.targets
@@ -1,0 +1,112 @@
+<Project>
+
+  <!-- Coalesce ReadmeFileInPackage to a boolean value. Default is true. -->
+  <PropertyGroup>
+    <ReadmeFileInPackage Condition="'$(ReadmeFileInPackage)' == ''">true</ReadmeFileInPackage>
+    <ReadmeFileInPackage Condition="'$(ReadmeFileInPackage)' != 'true'">false</ReadmeFileInPackage>
+  </PropertyGroup>
+
+  <!--
+    Include a README file in package:
+      - if ReadmeFileInPackage is false, just don't;
+      - if PackageReadmePath is specified, use it;
+      - otherwise, if PackageReadmeFile is specified, look for it in project directory and going up.
+        If a file is found, set PackageReadmePath to its full path;
+      - otherwise, look for a default README file. If a file is found,
+        set PackageReadmePath to its full path and PackageReadmeFile to its filename.
+  -->
+  <Choose>
+    <When Condition="!$(ReadmeFileInPackage)">
+      <PropertyGroup>
+        <PackageReadmeFile />
+        <PackageReadmePath />
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(PackageReadmePath)' != ''">
+      <PropertyGroup>
+        <PackageReadmeFile>$([System.IO.Path]::GetFileName('$(PackageReadmePath)'))</PackageReadmeFile>
+      </PropertyGroup>
+      <ItemGroup>
+        <EvaluationError Condition="!Exists('$(PackageReadmePath)')"
+                         Include="BVE1509"
+                         Text="Specified README file '$(PackageReadmePath)' does not exist." />
+      </ItemGroup>
+    </When>
+    <When Condition="'$(PackageReadmeFile)' != ''">
+      <PropertyGroup>
+        <PackageReadmePath>$([MSBuild]::GetPathOfFileAbove('$(PackageLicenseFile)', '$(MSBuildProjectDirectory)'))</PackageReadmePath>
+      </PropertyGroup>
+      <ItemGroup>
+        <EvaluationError Condition="'$(PackageReadmePath)' == ''"
+                         Include="BVE1510"
+                         Text="Specified README file '$(PackageReadmeFile)' was not found." />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <!--
+        Default README file can be one of (in order of discovery):
+          - Package-README.md
+          - package-readme.md
+          - NuGet-README.md
+          - nuget-readme.md
+          - NuGet.md
+          - nuget.md
+          - README.md
+          - readme.md
+
+        Files found outside repository are ignored.
+      -->
+      <PropertyGroup>
+        <PackageReadmePath>$([MSBuild]::GetPathOfFileAbove('Package-README.md', '$(MSBuildProjectDirectory)'))</PackageReadmePath>
+        <PackageReadmePath Condition="'$(PackageReadmePath)' != '' And !$(PackageReadmePath.StartsWith('$(HomeDirectory)'))" />
+      </PropertyGroup>
+      <PropertyGroup Condition="'$(PackageReadmePath)' == ''">
+        <PackageReadmePath>$([MSBuild]::GetPathOfFileAbove('package-readme.md', '$(MSBuildProjectDirectory)'))</PackageReadmePath>
+        <PackageReadmePath Condition="'$(PackageReadmePath)' != '' And !$(PackageReadmePath.StartsWith('$(HomeDirectory)'))" />
+      </PropertyGroup>
+      <PropertyGroup Condition="'$(PackageReadmePath)' == ''">
+        <PackageReadmePath>$([MSBuild]::GetPathOfFileAbove('NuGet-README.md', '$(MSBuildProjectDirectory)'))</PackageReadmePath>
+        <PackageReadmePath Condition="'$(PackageReadmePath)' != '' And !$(PackageReadmePath.StartsWith('$(HomeDirectory)'))" />
+      </PropertyGroup>
+      <PropertyGroup Condition="'$(PackageReadmePath)' == ''">
+        <PackageReadmePath>$([MSBuild]::GetPathOfFileAbove('nuget-readme.md', '$(MSBuildProjectDirectory)'))</PackageReadmePath>
+        <PackageReadmePath Condition="'$(PackageReadmePath)' != '' And !$(PackageReadmePath.StartsWith('$(HomeDirectory)'))" />
+      </PropertyGroup>
+      <PropertyGroup Condition="'$(PackageReadmePath)' == ''">
+        <PackageReadmePath>$([MSBuild]::GetPathOfFileAbove('NuGet.md', '$(MSBuildProjectDirectory)'))</PackageReadmePath>
+        <PackageReadmePath Condition="'$(PackageReadmePath)' != '' And !$(PackageReadmePath.StartsWith('$(HomeDirectory)'))" />
+      </PropertyGroup>
+      <PropertyGroup Condition="'$(PackageReadmePath)' == ''">
+        <PackageReadmePath>$([MSBuild]::GetPathOfFileAbove('nuget.md', '$(MSBuildProjectDirectory)'))</PackageReadmePath>
+        <PackageReadmePath Condition="'$(PackageReadmePath)' != '' And !$(PackageReadmePath.StartsWith('$(HomeDirectory)'))" />
+      </PropertyGroup>
+      <PropertyGroup Condition="'$(PackageReadmePath)' == ''">
+        <PackageReadmePath>$([MSBuild]::GetPathOfFileAbove('README.md', '$(MSBuildProjectDirectory)'))</PackageReadmePath>
+        <PackageReadmePath Condition="'$(PackageReadmePath)' != '' And !$(PackageReadmePath.StartsWith('$(HomeDirectory)'))" />
+      </PropertyGroup>
+      <PropertyGroup Condition="'$(PackageReadmePath)' == ''">
+        <PackageReadmePath>$([MSBuild]::GetPathOfFileAbove('readme.md', '$(MSBuildProjectDirectory)'))</PackageReadmePath>
+        <PackageReadmePath Condition="'$(PackageReadmePath)' != '' And !$(PackageReadmePath.StartsWith('$(HomeDirectory)'))" />
+      </PropertyGroup>
+      <!-- Use found filename to set PackageReadmeFile. -->
+      <PropertyGroup Condition="'$(PackageReadmePath)' != ''">
+        <PackageReadmeFile>$([System.IO.Path]::GetFileName('$(PackageReadmePath)'))</PackageReadmeFile>
+      </PropertyGroup>
+      <!-- Error if not found. -->
+      <ItemGroup>
+        <EvaluationError Condition="'$(PackageReadmePath)' == ''"
+                         Include="BVE1511"
+                         Text="No README file found for package." />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+  <!-- Add README file to project items so the Pack target can find it.
+       https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/#add-a-readme-in-your-project-file-recommended
+  -->
+  <ItemGroup Condition="'$(PackageReadmePath)' != '' And '$(PackageReadmeFile)' != ''">
+    <Content Remove="$(PackageReadmePath)" />
+    <Content Include="$(PackageReadmePath)" Link="$(PackageReadmeFile)" Pack="true" PackagePath="\" Visible="false" />
+  </ItemGroup>
+
+</Project>

--- a/src/Buildvana.Sdk/Sdk/PackageVersions.props
+++ b/src/Buildvana.Sdk/Sdk/PackageVersions.props
@@ -13,7 +13,7 @@
     <BV_PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <BV_PackageVersion Include="Nullable" Version="1.3.0" />
     <BV_PackageVersion Include="ReSharper.ExportAnnotations.Task" Version="1.4.0" />
-    <BV_PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.406" />
+    <BV_PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
     <BV_PackageVersion Include="Tools.InnoDownloadPlugin" Version="1.5.1" />
     <BV_PackageVersion Include="Tools.InnoSetup" Version="6.2.1" />
   </ItemGroup>

--- a/test/Buildvana.Sdk.CodeGeneration.Tests/CodeGeneratorTest.cs
+++ b/test/Buildvana.Sdk.CodeGeneration.Tests/CodeGeneratorTest.cs
@@ -18,11 +18,11 @@ public class CodeGeneratorTest
     [TestCase("VisualBasic")]
     public void GenerateCode_ReturnsNonEmptyString(string languageStr)
     {
-        var assemblyAttribute = new AssemblyAttribute(
+        var assemblyAttribute = new AssemblyAttributeFragment(
             "System.Runtime.InteropServices.ComVisible",
             new[] { new OrderedParameter(false) });
 
-        var thisAssemblyClass = new ThisAssemblyClass(
+        var thisAssemblyClass = new ThisAssemblyClassFragment(
             null,
             "ThisAssembly",
             new[] { new Constant("Answer", 42) });


### PR DESCRIPTION
## Types of changes

- [ ] Bugfix
- [x] Enhancement (new and/or improved behavior)
- [ ] Refactoring (no functional changes)
- [ ] Code style update (no functional changes)
- [x] Dependencies added, updated, or removed
- [ ] Build related changes
- [ ] Repository infrastructure changes (e.g. changes to issue / PR templates)
- [ ] CI related changes
- [ ] Documentation update
- [ ] Other (please describe below)

## Proposed changes / fixed issues

For packable projects, automatically find a README.md file and include it in the NuGet package.

To disable this feature, set the `ReadmeFileInPackage` property to `false`.

Recognized names for the README file, in order of lookup, are:

- `Package-README.md`
- `package-readme.md`
- `NuGet-README.md`
- `nuget-readme.md`
- `NuGet.md`
- `nuget.md`
- `README.md`
- `readme.md`

Also updated some dependencies.

## Checklist

- [x] My contribution is my original work
- [ ] My contribution, or part of it, comes from projects with an MIT-compatible license AND I have updated the THIRD-PARTY-NOTICES file accordingly
- [x] I have added and/or updated related documentation (if applicable)
- [x] I have updated the "Unreleased changes" section in [CHANGELOG.md](https://github.com/Buildvana/Buildvana.Sdk/blob/main/CHANGELOG.md) according to the modifications I made
