### PR TITLE
Preserve JSON formatting when rewriting self-references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bugs fixed in this release
 
+- [Issue #243](https://github.com/Tenacom/Buildvana/issues/243) — `dotnet bv release` now rewrites `global.json`, `.config/dotnet-tools.json`, and `version.json` in place via a byte-level splice, preserving line endings, trailing newlines, indentation, comments, and BOM exactly as they were on disk. Previously, automatic dogfooding (and version-file updates) re-serialized the entire JSON document, producing all-lines-changed diffs and dropping the trailing newline.
+
 ### Known problems introduced by this release
 
 ## [1.1.4](https://github.com/Tenacom/Buildvanareleases/tag/1.1.4) (2026-04-27)

--- a/src/Buildvana.Tool/Services/SelfReferenceUpdater.cs
+++ b/src/Buildvana.Tool/Services/SelfReferenceUpdater.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Buildvana.Tool.Services.Versioning;
 using Buildvana.Tool.Utilities;
@@ -97,23 +96,6 @@ public sealed class SelfReferenceUpdater
         return modified;
     }
 
-    private static List<string> SnapshotPropertyNames(JsonObject json)
-    {
-        // Materialize the names so callers can mutate the object while iterating.
-        var names = new List<string>(json.Count);
-        foreach (var kvp in json)
-        {
-            names.Add(kvp.Key);
-        }
-
-        return names;
-    }
-
-    private static bool IsAlreadySet(JsonObject holder, string key, string value)
-        => holder[key] is JsonValue current
-           && current.TryGetValue<string>(out var currentValue)
-           && string.Equals(currentValue, value, StringComparison.Ordinal);
-
     private Dictionary<string, string> DiscoverProducedPackages()
     {
         var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -143,56 +125,33 @@ public sealed class SelfReferenceUpdater
 
     private bool UpdateJsonContainer(FilePath path, Dictionary<string, string> produced, string container, string? versionPropertyName)
     {
-        var json = _context.LoadJsonObject(path);
-        if (json[container] is not JsonObject entries)
+        // Splice the new version directly over the existing one in the source bytes, so unrelated
+        // bytes — line endings, indentation, the trailing newline (if any), comments, BOM — survive untouched.
+        // The expected location of each version string differs by container shape:
+        //   - versionPropertyName == null → at depth 2 with path [container, packageId];
+        //   - versionPropertyName != null → at depth 3 with path [container, packageId, versionPropertyName].
+        return _context.RewriteJsonStringValues(path, (propertyPath, currentValue) =>
         {
-            return false;
-        }
-
-        var changed = false;
-        foreach (var name in SnapshotPropertyNames(entries))
-        {
-            if (!produced.TryGetValue(name, out var newVersion))
-            {
-                continue;
-            }
-
-            // Resolve where the version value actually lives.
-            // - versionPropertyName == null → the entry value itself IS the version string.
-            // - versionPropertyName != null → the entry is an object holding the version under that property.
-            JsonObject holder;
-            string key;
             if (versionPropertyName is null)
             {
-                holder = entries;
-                key = name;
+                if (propertyPath.Count != 2 || propertyPath[0] != container)
+                {
+                    return null;
+                }
             }
             else
             {
-                if (entries[name] is not JsonObject entryObject)
+                if (propertyPath.Count != 3 || propertyPath[0] != container || propertyPath[2] != versionPropertyName)
                 {
-                    continue;
+                    return null;
                 }
-
-                holder = entryObject;
-                key = versionPropertyName;
             }
 
-            if (IsAlreadySet(holder, key, newVersion))
-            {
-                continue;
-            }
-
-            holder[key] = JsonValue.Create(newVersion);
-            changed = true;
-        }
-
-        if (changed)
-        {
-            _context.SaveJson(json, path);
-        }
-
-        return changed;
+            var packageId = propertyPath[1];
+            return produced.TryGetValue(packageId, out var newVersion) && !string.Equals(currentValue, newVersion, StringComparison.Ordinal)
+                ? newVersion
+                : null;
+        });
     }
 
     private bool UpdateMsBuildXml(FilePath path, Dictionary<string, string> produced, string[] tagNames)

--- a/src/Buildvana.Tool/Services/Versioning/VersionFile.cs
+++ b/src/Buildvana.Tool/Services/Versioning/VersionFile.cs
@@ -15,16 +15,15 @@ namespace Buildvana.Tool.Services.Versioning;
 public sealed class VersionFile
 {
     private const string VersionJsonPath = "version.json";
+    private const string VersionPropertyName = "version";
     private const string DefaultFirstUnstableTag = "preview";
 
     private readonly ICakeContext _context;
-    private readonly JsonNode _json;
 
-    private VersionFile(ICakeContext context, FilePath path, JsonNode json, VersionSpec versionSpec, string firstUnstableTag)
+    private VersionFile(ICakeContext context, FilePath path, VersionSpec versionSpec, string firstUnstableTag)
     {
         _context = context;
         Path = path.MakeAbsolute(_context.Environment);
-        _json = json;
         VersionSpec = versionSpec;
         FirstUnstableTag = firstUnstableTag;
     }
@@ -56,7 +55,7 @@ public sealed class VersionFile
 
         var path = new FilePath(VersionJsonPath);
         var json = context.LoadJsonObject(path);
-        var versionStr = context.GetJsonPropertyValue<string>(json, "version", path + " file");
+        var versionStr = context.GetJsonPropertyValue<string>(json, VersionPropertyName, path + " file");
         context.Ensure(VersionSpec.TryParse(versionStr, out var versionSpec), $"{VersionJsonPath} contains invalid version specification '{versionStr}'.");
         var firstUnstableTag = DefaultFirstUnstableTag;
         var release = json["release"];
@@ -69,7 +68,7 @@ public sealed class VersionFile
             }
         }
 
-        return new(context, path, json, versionSpec, firstUnstableTag);
+        return new(context, path, versionSpec, firstUnstableTag);
     }
 
     /// <summary>
@@ -93,7 +92,9 @@ public sealed class VersionFile
     /// </summary>
     public void Save()
     {
-        _json["version"] = JsonValue.Create(VersionSpec.ToString());
-        _context.SaveJson(_json, Path);
+        var newVersion = VersionSpec.ToString();
+        _ = _context.RewriteJsonStringValues(
+            Path,
+            (propertyPath, _) => propertyPath.Count == 1 && propertyPath[0] == VersionPropertyName ? newVersion : null);
     }
 }

--- a/src/Buildvana.Tool/Services/Versioning/VersionFile.cs
+++ b/src/Buildvana.Tool/Services/Versioning/VersionFile.cs
@@ -93,8 +93,13 @@ public sealed class VersionFile
     public void Save()
     {
         var newVersion = VersionSpec.ToString();
-        _ = _context.RewriteJsonStringValues(
+        var rewritten = _context.RewriteJsonStringValues(
             Path,
             (propertyPath, _) => propertyPath.Count == 1 && propertyPath[0] == VersionPropertyName ? newVersion : null);
+
+        // Load already validated that a top-level string "version" property exists, so a no-op here
+        // means either the on-disk file changed underneath us or VersionSpec.ToString() produced the
+        // same string the file already held — both cases would let the release flow stage stale data.
+        _context.Ensure(rewritten, $"Could not update {VersionJsonPath}: expected a top-level string '{VersionPropertyName}' property to rewrite.");
     }
 }

--- a/src/Buildvana.Tool/Utilities/CakeContextExtensions-Json.cs
+++ b/src/Buildvana.Tool/Utilities/CakeContextExtensions-Json.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Json;
@@ -119,6 +121,89 @@ partial class CakeContextExtensions
     }
 
     /// <summary>
+    /// Rewrites the value of one or more JSON string properties in a file in place, preserving every byte
+    /// not covered by an actual replacement.
+    /// </summary>
+    /// <param name="this">The Cake context.</param>
+    /// <param name="path">The path of the file to rewrite.</param>
+    /// <param name="rewriter">A callback invoked once per string-valued property of an object reached during
+    /// a depth-first walk of the document. Returning <see langword="null"/> (or the unchanged value) leaves
+    /// the property alone; returning a different string queues a splice at that exact location.</param>
+    /// <returns><see langword="true"/> if at least one property was actually changed and the file was rewritten;
+    /// <see langword="false"/> if no callback returned a changed value (the file is left untouched on disk).</returns>
+    /// <remarks>
+    /// <para>Unlike a load-mutate-serialize cycle (e.g. <see cref="LoadJsonObject"/> + <see cref="SaveJson"/>),
+    /// this method does not reformat the document: line endings, indentation, blank lines, comments, the
+    /// trailing newline (if any) and a UTF-8 BOM (if any) are preserved exactly.</para>
+    /// <para>Replacements are JSON-encoded with <see cref="JavaScriptEncoder.UnsafeRelaxedJsonEscaping"/>,
+    /// matching the policy used by <see cref="SaveJson"/>.</para>
+    /// </remarks>
+    public static bool RewriteJsonStringValues(this ICakeContext @this, FilePath path, JsonStringValueRewriter rewriter)
+    {
+        Guard.IsNotNull(path);
+        Guard.IsNotNull(rewriter);
+
+        var fullPath = path.FullPath;
+        byte[] originalBytes;
+        try
+        {
+            originalBytes = SysFile.ReadAllBytes(fullPath);
+        }
+        catch (IOException e)
+        {
+            return @this.Fail<bool>($"Could not read from {fullPath}: {e.Message}");
+        }
+
+        // Utf8JsonReader rejects a leading UTF-8 BOM; skip it for parsing but preserve it on rewrite.
+        var bomLength = HasUtf8Bom(originalBytes) ? 3 : 0;
+
+        List<JsonValueEdit> edits;
+        try
+        {
+            edits = CollectJsonStringEdits(originalBytes.AsSpan(bomLength), bomLength, rewriter);
+        }
+        catch (JsonException)
+        {
+            return @this.Fail<bool>($"{fullPath} does not contain valid JSON.");
+        }
+
+        if (edits.Count == 0)
+        {
+            return false;
+        }
+
+        // Walker emits edits in source order, so a single forward pass over the original bytes suffices.
+        using var output = new MemoryStream(originalBytes.Length + 64);
+        var cursor = 0;
+        foreach (var edit in edits)
+        {
+            if (edit.Start > cursor)
+            {
+                output.Write(originalBytes, cursor, edit.Start - cursor);
+            }
+
+            output.Write(edit.Replacement, 0, edit.Replacement.Length);
+            cursor = edit.Start + edit.Length;
+        }
+
+        if (cursor < originalBytes.Length)
+        {
+            output.Write(originalBytes, cursor, originalBytes.Length - cursor);
+        }
+
+        try
+        {
+            SysFile.WriteAllBytes(fullPath, output.ToArray());
+        }
+        catch (IOException e)
+        {
+            @this.Fail($"Could not write to {fullPath}: {e.Message}");
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Gets the value of a property from a JSON object. Fails the build if not successful.
     /// </summary>
     /// <typeparam name="T">The desired type of the property value.</typeparam>
@@ -142,5 +227,83 @@ partial class CakeContextExtensions
             default:
                 return @this.Fail<T>($"Json property {propertyName} in {objectDescription} is a {property.GetType().Name}, not a {nameof(JsonValue)}.");
         }
+    }
+
+    private static bool HasUtf8Bom(ReadOnlySpan<byte> bytes)
+        => bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
+
+    private static List<JsonValueEdit> CollectJsonStringEdits(ReadOnlySpan<byte> jsonSpan, int offsetInFile, JsonStringValueRewriter rewriter)
+    {
+        var reader = new Utf8JsonReader(
+            jsonSpan,
+            new JsonReaderOptions
+            {
+                AllowTrailingCommas = true,
+                CommentHandling = JsonCommentHandling.Skip,
+            });
+
+        var edits = new List<JsonValueEdit>();
+        var pathSegments = new List<string>();
+        string? pendingProperty = null;
+        while (reader.Read())
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.PropertyName:
+                    pendingProperty = reader.GetString();
+                    break;
+
+                case JsonTokenType.StartObject:
+                case JsonTokenType.StartArray:
+                    if (pendingProperty is not null)
+                    {
+                        pathSegments.Add(pendingProperty);
+                        pendingProperty = null;
+                    }
+
+                    break;
+
+                case JsonTokenType.EndObject:
+                case JsonTokenType.EndArray:
+                    if (pathSegments.Count > 0)
+                    {
+                        pathSegments.RemoveAt(pathSegments.Count - 1);
+                    }
+
+                    break;
+
+                case JsonTokenType.String:
+                    // Only invoke the rewriter for string values that are direct properties of an object;
+                    // string elements of arrays have no pending property name and are skipped on purpose.
+                    if (pendingProperty is not null)
+                    {
+                        var currentValue = reader.GetString()!;
+                        pathSegments.Add(pendingProperty);
+                        var newValue = rewriter(pathSegments, currentValue);
+                        pathSegments.RemoveAt(pathSegments.Count - 1);
+                        pendingProperty = null;
+
+                        if (newValue is not null && !string.Equals(newValue, currentValue, StringComparison.Ordinal))
+                        {
+                            // TokenStartIndex points to the opening quote; ValueSpan covers the bytes
+                            // between the quotes (escape sequences included). The closing quote and any
+                            // surrounding whitespace are deliberately untouched.
+                            var innerStart = (int)reader.TokenStartIndex + 1 + offsetInFile;
+                            var innerLength = reader.ValueSpan.Length;
+                            var encoded = JsonEncodedText.Encode(newValue.AsSpan(), JavaScriptEncoder.UnsafeRelaxedJsonEscaping).EncodedUtf8Bytes.ToArray();
+                            edits.Add(new JsonValueEdit(innerStart, innerLength, encoded));
+                        }
+                    }
+
+                    break;
+
+                default:
+                    // Any other primitive value (Number / True / False / Null) consumes the pending name.
+                    pendingProperty = null;
+                    break;
+            }
+        }
+
+        return edits;
     }
 }

--- a/src/Buildvana.Tool/Utilities/CakeContextExtensions-Json.cs
+++ b/src/Buildvana.Tool/Utilities/CakeContextExtensions-Json.cs
@@ -288,22 +288,8 @@ partial class CakeContextExtensions
                     // string elements of arrays have no pending property name and are skipped on purpose.
                     if (pendingProperty is not null)
                     {
-                        var currentValue = reader.GetString()!;
-                        pathSegments.Add(pendingProperty);
-                        var newValue = rewriter(pathSegments, currentValue);
-                        pathSegments.RemoveAt(pathSegments.Count - 1);
+                        TryRecordStringEdit(ref reader, offsetInFile, rewriter, pathSegments, pendingProperty, edits);
                         pendingProperty = null;
-
-                        if (newValue is not null && !string.Equals(newValue, currentValue, StringComparison.Ordinal))
-                        {
-                            // TokenStartIndex points to the opening quote; ValueSpan covers the bytes
-                            // between the quotes (escape sequences included). The closing quote and any
-                            // surrounding whitespace are deliberately untouched.
-                            var innerStart = (int)reader.TokenStartIndex + 1 + offsetInFile;
-                            var innerLength = reader.ValueSpan.Length;
-                            var encoded = JsonEncodedText.Encode(newValue.AsSpan(), JavaScriptEncoder.UnsafeRelaxedJsonEscaping).EncodedUtf8Bytes.ToArray();
-                            edits.Add(new JsonValueEdit(innerStart, innerLength, encoded));
-                        }
                     }
 
                     break;
@@ -316,5 +302,32 @@ partial class CakeContextExtensions
         }
 
         return edits;
+    }
+
+    private static void TryRecordStringEdit(
+        ref Utf8JsonReader reader,
+        int offsetInFile,
+        JsonStringValueRewriter rewriter,
+        List<string> pathSegments,
+        string propertyName,
+        List<JsonValueEdit> edits)
+    {
+        var currentValue = reader.GetString()!;
+        pathSegments.Add(propertyName);
+        var newValue = rewriter(pathSegments, currentValue);
+        pathSegments.RemoveAt(pathSegments.Count - 1);
+
+        if (newValue is null || string.Equals(newValue, currentValue, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        // TokenStartIndex points to the opening quote; ValueSpan covers the bytes
+        // between the quotes (escape sequences included). The closing quote and any
+        // surrounding whitespace are deliberately untouched.
+        var innerStart = (int)reader.TokenStartIndex + 1 + offsetInFile;
+        var innerLength = reader.ValueSpan.Length;
+        var encoded = JsonEncodedText.Encode(newValue.AsSpan(), JavaScriptEncoder.UnsafeRelaxedJsonEscaping).EncodedUtf8Bytes.ToArray();
+        edits.Add(new JsonValueEdit(innerStart, innerLength, encoded));
     }
 }

--- a/src/Buildvana.Tool/Utilities/CakeContextExtensions-Json.cs
+++ b/src/Buildvana.Tool/Utilities/CakeContextExtensions-Json.cs
@@ -244,6 +244,12 @@ partial class CakeContextExtensions
 
         var edits = new List<JsonValueEdit>();
         var pathSegments = new List<string>();
+
+        // Parallel stack: one entry per open container, true iff that container's start consumed
+        // a property name (i.e. pushed onto pathSegments). Without this, EndObject/EndArray would
+        // pop a segment for *every* close — including containers that are array elements, which
+        // never push — corrupting the path for siblings that follow.
+        var containerPushedSegment = new Stack<bool>();
         string? pendingProperty = null;
         while (reader.Read())
         {
@@ -258,14 +264,19 @@ partial class CakeContextExtensions
                     if (pendingProperty is not null)
                     {
                         pathSegments.Add(pendingProperty);
+                        containerPushedSegment.Push(true);
                         pendingProperty = null;
+                    }
+                    else
+                    {
+                        containerPushedSegment.Push(false);
                     }
 
                     break;
 
                 case JsonTokenType.EndObject:
                 case JsonTokenType.EndArray:
-                    if (pathSegments.Count > 0)
+                    if (containerPushedSegment.Pop())
                     {
                         pathSegments.RemoveAt(pathSegments.Count - 1);
                     }

--- a/src/Buildvana.Tool/Utilities/CakeContextExtensions.JsonValueEdit.cs
+++ b/src/Buildvana.Tool/Utilities/CakeContextExtensions.JsonValueEdit.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Buildvana.Tool.Utilities;
+
+partial class CakeContextExtensions
+{
+    private readonly record struct JsonValueEdit(int Start, int Length, byte[] Replacement);
+}

--- a/src/Buildvana.Tool/Utilities/JsonStringValueRewriter.cs
+++ b/src/Buildvana.Tool/Utilities/JsonStringValueRewriter.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace Buildvana.Tool.Utilities;
+
+/// <summary>
+/// Computes a replacement for a JSON string value visited during a structural walk of a JSON document.
+/// </summary>
+/// <param name="propertyPath">
+/// The chain of property names from the document root to the current value. The same list instance is
+/// reused across invocations and mutated by the walker; do not retain it past the callback's return.
+/// Array indices are not included; the callback is only invoked for string values that are direct
+/// properties of an object.
+/// </param>
+/// <param name="currentValue">The string value currently in the document, fully unescaped.</param>
+/// <returns>The new value to splice into the document, or <see langword="null"/> to leave it unchanged.</returns>
+public delegate string? JsonStringValueRewriter(IReadOnlyList<string> propertyPath, string currentValue);


### PR DESCRIPTION
## Summary

Fix #243. Replaces the JSON load-mutate-serialize pattern in `SelfReferenceUpdater` and `VersionFile.Save` with a byte-level splice that preserves the original file's line endings, trailing newline, indentation, comments, and BOM exactly. Only the bytes between the quotes of the target string value(s) are rewritten; everything else is copied verbatim.

## Approach

A new `ICakeContext.RewriteJsonStringValues(FilePath, JsonStringValueRewriter)` extension drives a `Utf8JsonReader` over the source bytes, calling back the supplied `JsonStringValueRewriter` once per string-valued object property with its current value and a property-path stack. When the callback returns a new string, the `(start, length)` of the inner content (between the quotes) is recorded; after the walk, a single forward pass over the original bytes emits unchanged spans verbatim and splices in JSON-encoded replacements at the recorded offsets.

A UTF-8 BOM, if present, is sliced off before parsing (since `Utf8JsonReader` rejects it) and preserved at the start of the output.

## Affected sites

- `SelfReferenceUpdater.UpdateJsonContainer` — handles both `global.json` (versions are direct property values under `msbuild-sdks`) and `.config/dotnet-tools.json` (versions live under `tools.{id}.version`). The previous `JsonNode` mutation + `SaveJson` is gone, along with the now-unused `SnapshotPropertyNames` and `IsAlreadySet` helpers.
- `VersionFile.Save` — now splices the top-level `version` value directly. The `_json` field and the `JsonNode` constructor parameter are no longer needed and have been removed.

`SaveJson` itself is left in place — no other callers, but it's a coherent counterpart to `LoadJsonObject` that may be useful for future code that genuinely wants to write a fresh JSON document.

## Verified manually

A throwaway test harness exercised the helper against eight scenarios — LF / CRLF, with / without trailing newline, with / without BOM, with comments, no-op rewriter, same-value rewriter, length-changing replacement, and all three target-file shapes. All assertions passed; bytes outside the spliced regions were preserved exactly. (Test code not in this PR.)

## Test plan

- [ ] `dotnet build` is clean
- [ ] On the next "Prepare release" commit, `global.json` and `.config/dotnet-tools.json` show only the changed `version` value(s) in the diff (no all-lines-changed, no `\ No newline at end of file`)
- [ ] `version.json` updates produced by `dotnet bv release` show only the changed `version` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)