### PR TITLE
IBuildHost abstraction and host adapters

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -7,10 +7,15 @@ It consists of an MSBuild SDK working in addition to the SDK specified in projec
 
 Sub-projects under `src/`:
 
+- `Buildvana.Core.Abstractions` — host-agnostic contracts shared by Buildvana libraries (currently `IBuildHost`). No host references (no Cake, no MSBuild). Not packaged: it is an internal seam between sibling projects in this repo.
 - `Buildvana.Sdk.Tasks` — compiled MSBuild tasks.
 - `Buildvana.Sdk.SourceGenerators` — Roslyn source generators.
 - `Buildvana.Sdk` — MSBuild SDK. Packages the above two projects and contains the SDK props/targets.
 - `Buildvana.Tool` — .NET CLI tool (`bv`).
+
+### `.Abstractions` discipline
+
+`Buildvana.Core.Abstractions` (and any future `*.Abstractions` library) contains contracts only — no concrete helpers, no domain types, no host references. If something has a concrete implementation that could justify its own library, it does not belong in `.Abstractions`. Concrete adapters (e.g. `CakeBuildHost`, `MSBuildTaskHost`) live in the project that owns the host (`Buildvana.Tool`, `Buildvana.Sdk.Tasks`), not in the abstractions library.
 
 ## Target platforms
 

--- a/Buildvana.slnx
+++ b/Buildvana.slnx
@@ -30,6 +30,7 @@
     <File Path="docs/modules/Wine.md" />
   </Folder>
   <Folder Name="/src/">
+    <Project Path="src/Buildvana.Core.Abstractions/Buildvana.Core.Abstractions.csproj" />
     <Project Path="src/Buildvana.Sdk.SourceGenerators/Buildvana.Sdk.SourceGenerators.csproj" />
     <Project Path="src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj" />
     <Project Path="src/Buildvana.Sdk/Buildvana.Sdk.csproj" />

--- a/Buildvana.slnx.DotSettings
+++ b/Buildvana.slnx.DotSettings
@@ -467,6 +467,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CIDR/@EntryIndexedValue">CIDR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IO/@EntryIndexedValue">IO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MS/@EntryIndexedValue">MS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NA/@EntryIndexedValue">NA</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OK/@EntryIndexedValue">OK</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SQ/@EntryIndexedValue">SQ</s:String>

--- a/src/Buildvana.Core.Abstractions/BuildHostExtensions.cs
+++ b/src/Buildvana.Core.Abstractions/BuildHostExtensions.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Buildvana.Core;
+
+/// <summary>
+/// Provides default extension methods for <see cref="IBuildHost"/>, derived from its primary members.
+/// </summary>
+public static class BuildHostExtensions
+{
+    /// <summary>
+    /// <para>Fails the build with the specified message.</para>
+    /// <para>This method does not return.</para>
+    /// </summary>
+    /// <typeparam name="T">The expected return type.</typeparam>
+    /// <param name="host">The build host.</param>
+    /// <param name="message">A message explaining the reason for failing the build.</param>
+    /// <returns>This method never returns.</returns>
+    [DoesNotReturn]
+    public static T Fail<T>(this IBuildHost host, string message)
+    {
+        host.Fail(message);
+        throw new UnreachableException();
+    }
+
+    /// <summary>
+    /// Fails the build with the specified message if a condition is not verified.
+    /// </summary>
+    /// <param name="host">The build host.</param>
+    /// <param name="condition">The condition to verify.</param>
+    /// <param name="message">A message explaining the reason for failing the build.</param>
+    public static void Ensure(this IBuildHost host, [DoesNotReturnIf(false)] bool condition, string message)
+    {
+        if (!condition)
+        {
+            host.Fail(message);
+        }
+    }
+
+    /// <summary>
+    /// Logs a message at <see cref="LogLevel.Trace"/> level.
+    /// </summary>
+    /// <param name="host">The build host.</param>
+    /// <param name="message">The message to log.</param>
+    public static void LogTrace(this IBuildHost host, string message) => host.Log(LogLevel.Trace, message);
+
+    /// <summary>
+    /// Logs a message at <see cref="LogLevel.Debug"/> level.
+    /// </summary>
+    /// <param name="host">The build host.</param>
+    /// <param name="message">The message to log.</param>
+    public static void LogDebug(this IBuildHost host, string message) => host.Log(LogLevel.Debug, message);
+
+    /// <summary>
+    /// Logs a message at <see cref="LogLevel.Information"/> level.
+    /// </summary>
+    /// <param name="host">The build host.</param>
+    /// <param name="message">The message to log.</param>
+    public static void LogInformation(this IBuildHost host, string message) => host.Log(LogLevel.Information, message);
+
+    /// <summary>
+    /// Logs a message at <see cref="LogLevel.Warning"/> level.
+    /// </summary>
+    /// <param name="host">The build host.</param>
+    /// <param name="message">The message to log.</param>
+    public static void LogWarning(this IBuildHost host, string message) => host.Log(LogLevel.Warning, message);
+
+    /// <summary>
+    /// Logs a message at <see cref="LogLevel.Error"/> level.
+    /// </summary>
+    /// <param name="host">The build host.</param>
+    /// <param name="message">The message to log.</param>
+    public static void LogError(this IBuildHost host, string message) => host.Log(LogLevel.Error, message);
+}

--- a/src/Buildvana.Core.Abstractions/Buildvana.Core.Abstractions.csproj
+++ b/src/Buildvana.Core.Abstractions/Buildvana.Core.Abstractions.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Buildvana Core Abstractions</Title>
+    <Description>Host-agnostic contracts shared by Buildvana libraries. Contracts only — no concrete helpers.</Description>
+    <RootNamespace>Buildvana.Core</RootNamespace>
+    <TargetFramework>$(StandardTfm)</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Buildvana.Core.Abstractions/IBuildHost.cs
+++ b/src/Buildvana.Core.Abstractions/IBuildHost.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Buildvana.Core;
+
+/// <summary>
+/// <para>The contract by which any reusable Buildvana library reports failures and log output to its host.</para>
+/// <para>Implementations adapt host runtimes (Cake, MSBuild tasks, etc.) so that libraries built on top of this
+/// interface remain host-agnostic.</para>
+/// </summary>
+/// <remarks>
+/// <para>Implementations of <see cref="Fail(string)"/> must throw an exception appropriate to the host.
+/// The thrown exception's message is guaranteed to end up in the host's log exactly once, through whichever
+/// path the host considers canonical.</para>
+/// </remarks>
+public interface IBuildHost
+{
+    /// <summary>
+    /// <para>Fails the build with the specified message.</para>
+    /// <para>This method does not return.</para>
+    /// </summary>
+    /// <param name="message">A message explaining the reason for failing the build.</param>
+    [DoesNotReturn]
+    void Fail(string message);
+
+    /// <summary>
+    /// Returns a value indicating whether log entries at the specified <paramref name="level"/> are emitted.
+    /// </summary>
+    /// <param name="level">The severity level to check.</param>
+    /// <returns><see langword="true"/> if entries at <paramref name="level"/> would be emitted; <see langword="false"/> otherwise.</returns>
+    bool IsEnabled(LogLevel level);
+
+    /// <summary>
+    /// Logs a message at the specified severity <paramref name="level"/>.
+    /// </summary>
+    /// <param name="level">The severity level to log at.</param>
+    /// <param name="message">The message to log.</param>
+    void Log(LogLevel level, string message);
+}

--- a/src/Buildvana.Core.Abstractions/LogLevel.cs
+++ b/src/Buildvana.Core.Abstractions/LogLevel.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Buildvana.Core;
+
+/// <summary>
+/// Severity levels for messages logged through <see cref="IBuildHost"/>.
+/// Numerically higher values indicate higher severity, matching dotnet's logging vocabulary.
+/// </summary>
+public enum LogLevel
+{
+    /// <summary>
+    /// Lowest-detail messages, visible only at <c>diagnostic</c> verbosity.
+    /// </summary>
+    Trace = 0,
+
+    /// <summary>
+    /// Detailed diagnostic messages, visible at <c>detailed</c> verbosity and above.
+    /// </summary>
+    Debug = 1,
+
+    /// <summary>
+    /// Routine progress messages, visible at <c>normal</c> verbosity and above.
+    /// </summary>
+    Information = 2,
+
+    /// <summary>
+    /// Non-fatal anomalies, visible at <c>minimal</c> verbosity and above.
+    /// </summary>
+    Warning = 3,
+
+    /// <summary>
+    /// Errors that do not by themselves stop the build, visible at every verbosity except suppressed.
+    /// </summary>
+    Error = 4,
+}

--- a/src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj
+++ b/src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Buildvana.Core.Abstractions\Buildvana.Core.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="All" />

--- a/src/Buildvana.Sdk.Tasks/MSBuildTaskHost.cs
+++ b/src/Buildvana.Sdk.Tasks/MSBuildTaskHost.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Buildvana.Core;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Buildvana.Sdk;
+
+internal sealed class MSBuildTaskHost : IBuildHost
+{
+    private readonly TaskLoggingHelper _log;
+    private readonly EngineServices? _engineServices;
+
+    public MSBuildTaskHost(TaskLoggingHelper log, IBuildEngine engine)
+    {
+        ArgumentNullException.ThrowIfNull(log);
+        ArgumentNullException.ThrowIfNull(engine);
+        _log = log;
+        _engineServices = (engine as IBuildEngine10)?.EngineServices;
+    }
+
+    [DoesNotReturn]
+    public void Fail(string message) => BuildErrorException.ThrowNew(message);
+
+    public bool IsEnabled(LogLevel level) => level switch
+    {
+        LogLevel.Trace => LogsMessagesOfImportance(MessageImportance.Low),
+        LogLevel.Debug => LogsMessagesOfImportance(MessageImportance.Low),
+        LogLevel.Information => LogsMessagesOfImportance(MessageImportance.Normal),
+        LogLevel.Warning => true,
+        LogLevel.Error => true,
+        _ => throw new ArgumentOutOfRangeException(nameof(level), level, null),
+    };
+
+    public void Log(LogLevel level, string message)
+    {
+        switch (level)
+        {
+            case LogLevel.Trace:
+                _log.LogMessage(MessageImportance.Low, message);
+                break;
+            case LogLevel.Debug:
+                _log.LogMessage(MessageImportance.Low, message);
+                break;
+            case LogLevel.Information:
+                _log.LogMessage(MessageImportance.Normal, message);
+                break;
+            case LogLevel.Warning:
+                _log.LogWarning(message);
+                break;
+            case LogLevel.Error:
+                _log.LogError(message);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(level), level, null);
+        }
+    }
+
+    private bool LogsMessagesOfImportance(MessageImportance importance)
+        => _engineServices?.LogsMessagesOfImportance(importance) ?? true;
+}

--- a/src/Buildvana.Sdk.Tasks/Tasks/BuildvanaSdkTask.cs
+++ b/src/Buildvana.Sdk.Tasks/Tasks/BuildvanaSdkTask.cs
@@ -2,6 +2,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using Buildvana.Core;
 using Buildvana.Sdk.Internal;
 using Microsoft.Build.Utilities;
 
@@ -9,6 +10,8 @@ namespace Buildvana.Sdk.Tasks;
 
 public abstract class BuildvanaSdkTask : Task
 {
+    protected IBuildHost Host => field ??= new MSBuildTaskHost(Log, BuildEngine);
+
     public sealed override bool Execute()
     {
         try

--- a/src/Buildvana.Sdk.Tasks/Tasks/GetWinePath.cs
+++ b/src/Buildvana.Sdk.Tasks/Tasks/GetWinePath.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Globalization;
+using System.Text;
+using Buildvana.Core;
 using Buildvana.Sdk.Internal;
 using Buildvana.Sdk.Resources;
 using Microsoft.Build.Framework;
@@ -9,6 +12,8 @@ namespace Buildvana.Sdk.Tasks;
 
 public sealed class GetWinePath : BuildvanaSdkTask
 {
+    private static readonly CompositeFormat MissingParameterFormat = CompositeFormat.Parse(Strings.MissingParameterFmt);
+
     public string BasePath { get; set; } = string.Empty;
 
     [Required]
@@ -19,10 +24,9 @@ public sealed class GetWinePath : BuildvanaSdkTask
 
     protected override Undefined Run()
     {
-        if (string.IsNullOrEmpty(HostPath))
-        {
-            return BuildErrorException.ThrowNew<Undefined>(Strings.MissingParameterFmt, nameof(HostPath));
-        }
+        Host.Ensure(
+            !string.IsNullOrEmpty(HostPath),
+            string.Format(CultureInfo.InvariantCulture, MissingParameterFormat, nameof(HostPath)));
 
         WinePath = WinePathUtility.ConvertToWinePath(HostPath, BasePath);
         return Undefined.Value;

--- a/src/Buildvana.Tool/Buildvana.Tool.csproj
+++ b/src/Buildvana.Tool/Buildvana.Tool.csproj
@@ -18,6 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Buildvana.Core.Abstractions\Buildvana.Core.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Cake.Frosting" />
     <PackageReference Include="Cake.Http" />
     <PackageReference Include="CommunityToolkit.Diagnostics" />

--- a/src/Buildvana.Tool/Infrastructure/BuildContext.cs
+++ b/src/Buildvana.Tool/Infrastructure/BuildContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using Buildvana.Core;
 using Buildvana.Tool.Services;
 using Buildvana.Tool.Services.Git;
 using Buildvana.Tool.Services.PublicApiFiles;
@@ -25,6 +26,7 @@ public sealed class BuildContext : FrostingContext
         Guard.IsNotNull(context);
         _services = new ServiceCollection()
             .AddSingleton(context)
+            .AddSingleton<IBuildHost, CakeBuildHost>()
             .AddSingleton<GitService>()
             .AddSingleton<PublicApiFilesService>()
             .AddSingleton(ServerAdapter.Create)

--- a/src/Buildvana.Tool/Infrastructure/CakeBuildHost.cs
+++ b/src/Buildvana.Tool/Infrastructure/CakeBuildHost.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Buildvana.Core;
+using Cake.Common.Diagnostics;
+using Cake.Core;
+using Cake.Core.Diagnostics;
+using CommunityToolkit.Diagnostics;
+using LogLevel = Buildvana.Core.LogLevel;
+
+namespace Buildvana.Tool.Infrastructure;
+
+public sealed class CakeBuildHost : IBuildHost
+{
+    private readonly ICakeContext _context;
+
+    public CakeBuildHost(ICakeContext context)
+    {
+        Guard.IsNotNull(context);
+        _context = context;
+    }
+
+    [DoesNotReturn]
+    public void Fail(string message)
+    {
+        _context.Error(message);
+        throw new CakeException(message);
+    }
+
+    public bool IsEnabled(LogLevel level) => level switch
+    {
+        LogLevel.Trace => _context.Log.Verbosity >= Verbosity.Diagnostic,
+        LogLevel.Debug => _context.Log.Verbosity >= Verbosity.Verbose,
+        LogLevel.Information => _context.Log.Verbosity >= Verbosity.Normal,
+        LogLevel.Warning => _context.Log.Verbosity >= Verbosity.Minimal,
+        LogLevel.Error => _context.Log.Verbosity >= Verbosity.Quiet,
+        _ => throw new ArgumentOutOfRangeException(nameof(level), level, null),
+    };
+
+    public void Log(LogLevel level, string message)
+    {
+        switch (level)
+        {
+            case LogLevel.Trace:
+                _context.Debug(message);
+                break;
+            case LogLevel.Debug:
+                _context.Verbose(message);
+                break;
+            case LogLevel.Information:
+                _context.Information(message);
+                break;
+            case LogLevel.Warning:
+                _context.Warning(message);
+                break;
+            case LogLevel.Error:
+                _context.Error(message);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(level), level, null);
+        }
+    }
+}

--- a/src/Buildvana.Tool/Services/ChangelogService.cs
+++ b/src/Buildvana.Tool/Services/ChangelogService.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Buildvana.Core;
 using Buildvana.Tool.Services.ServerAdapters;
 using Buildvana.Tool.Services.Versioning;
 using Buildvana.Tool.Utilities;
@@ -31,18 +32,21 @@ public sealed partial class ChangelogService
     public const string FileName = "CHANGELOG.md";
 
     private readonly ICakeContext _context;
+    private readonly IBuildHost _host;
     private readonly ServerAdapter _server;
     private readonly VersionService _version;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ChangelogService"/> class.
     /// </summary>
-    public ChangelogService(ICakeContext context, ServerAdapter server, VersionService version)
+    public ChangelogService(ICakeContext context, IBuildHost host, ServerAdapter server, VersionService version)
     {
         Guard.IsNotNull(context);
+        Guard.IsNotNull(host);
         Guard.IsNotNull(server);
         Guard.IsNotNull(version);
         _context = context;
+        _host = host;
         _server = server;
         _version = version;
         Path = new FilePath(FileName);
@@ -86,7 +90,7 @@ public sealed partial class ChangelogService
             line = reader.ReadLine();
         } while (line != null && !sectionHeadingRegex.IsMatch(line));
 
-        _context.Ensure(line != null, $"{FileName} contains no sections.");
+        _host.Ensure(line != null, $"{FileName} contains no sections.");
         for (; ;)
         {
             line = reader.ReadLine();


### PR DESCRIPTION
## Summary

- Adds `Buildvana.Core.Abstractions` with `IBuildHost` (`Fail`, `Log(LogLevel, string)`, `IsEnabled(LogLevel)`) and a `BuildHostExtensions` static class that provides `Fail<T>`, `Ensure`, and the per-level `LogTrace` / `LogDebug` / `LogInformation` / `LogWarning` / `LogError` shorthand.
- `CakeBuildHost` (in `Buildvana.Tool`) wraps `ICakeContext` and is registered as `IBuildHost` in `BuildContext`'s DI container.
- `MSBuildTaskHost` (in `Buildvana.Sdk.Tasks`) wraps `TaskLoggingHelper` + `IBuildEngine` and is exposed via a `Host` property on `BuildvanaSdkTask`.
- Verifies each adapter by porting one call site: `ChangelogService.HasUnreleasedChanges` (Cake) and `GetWinePath.Run` (MSBuild). Wholesale migration of remaining callers is out of scope and lands incrementally as libraries are extracted.
- Documents the `.Abstractions` discipline rule in `.claude/rules/architecture.md`.

Closes #239.

## Test plan

- [x] `dotnet bv build` clean — 0 warnings, 0 errors.
- [ ] Behavior parity verified on CI after an interim publish (per project workflow — local `--dry-run` not available for `bv`).