### PR TITLE
Extract Buildvana.Core.Json library from Buildvana.Tool

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -7,11 +7,20 @@ It consists of an MSBuild SDK working in addition to the SDK specified in projec
 
 Sub-projects under `src/`:
 
-- `Buildvana.Core.Abstractions` — host-agnostic contracts shared by Buildvana libraries (currently `IBuildHost`). No host references (no Cake, no MSBuild). Not packaged: it is an internal seam between sibling projects in this repo.
+- `Buildvana.Core.Abstractions` — host-agnostic contracts shared by Buildvana libraries (currently `IBuildHost`). No host references (no Cake, no MSBuild).
+- `Buildvana.Core.Json` — JSON loading, parsing, saving, and in-place rewriting helpers built on `IBuildHost`.
 - `Buildvana.Sdk.Tasks` — compiled MSBuild tasks.
 - `Buildvana.Sdk.SourceGenerators` — Roslyn source generators.
 - `Buildvana.Sdk` — MSBuild SDK. Packages the above two projects and contains the SDK props/targets.
 - `Buildvana.Tool` — .NET CLI tool (`bv`).
+
+### Project tiers
+
+Project names follow a three-tier convention:
+
+- `Buildvana.Core.*` — internal libraries shared between sibling projects in this repo. Not packaged. May depend only on `Buildvana.Core.Abstractions` and standard libraries; no host references (Cake, MSBuild, etc.).
+- `Buildvana.Sdk.*` — the MSBuild SDK and its components (tasks, source generators). Only `Buildvana.Sdk` is packaged; it bundles the others.
+- `Buildvana.Tool` — the `bv` .NET CLI global tool. Packaged as a `dotnet tool`.
 
 ### `.Abstractions` discipline
 

--- a/Buildvana.slnx
+++ b/Buildvana.slnx
@@ -32,6 +32,7 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Buildvana.Core.Abstractions/Buildvana.Core.Abstractions.csproj" />
+    <Project Path="src/Buildvana.Core.Json/Buildvana.Core.Json.csproj" />
     <Project Path="src/Buildvana.Sdk.SourceGenerators/Buildvana.Sdk.SourceGenerators.csproj" />
     <Project Path="src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj" />
     <Project Path="src/Buildvana.Sdk/Buildvana.Sdk.csproj" />

--- a/src/Buildvana.Core.Json/Buildvana.Core.Json.csproj
+++ b/src/Buildvana.Core.Json/Buildvana.Core.Json.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Buildvana JSON Helpers</Title>
+    <Description>JSON loading, parsing, saving, and in-place rewriting helpers that report failures through an IBuildHost.</Description>
+    <TargetFramework>$(StandardTfm)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Buildvana.Core.Abstractions\Buildvana.Core.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Diagnostics" />
+  </ItemGroup>
+
+</Project>

--- a/src/Buildvana.Core.Json/JsonBuildHostExtensions.JsonValueEdit.cs
+++ b/src/Buildvana.Core.Json/JsonBuildHostExtensions.JsonValueEdit.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Buildvana.Tool.Utilities;
+namespace Buildvana.Core.Json;
 
 partial class JsonBuildHostExtensions
 {

--- a/src/Buildvana.Core.Json/JsonBuildHostExtensions.cs
+++ b/src/Buildvana.Core.Json/JsonBuildHostExtensions.cs
@@ -7,12 +7,10 @@ using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Buildvana.Core;
-using Cake.Core.IO;
 using CommunityToolkit.Diagnostics;
 using SysFile = System.IO.File;
 
-namespace Buildvana.Tool.Utilities;
+namespace Buildvana.Core.Json;
 
 /// <summary>
 /// Provides JSON-related helpers that fail the build through an <see cref="IBuildHost"/> on parse or I/O errors.
@@ -58,15 +56,14 @@ public static partial class JsonBuildHostExtensions
     /// <param name="this">The build host.</param>
     /// <param name="path">The path of the file to parse.</param>
     /// <returns>The parsed object.</returns>
-    public static JsonObject LoadJsonObject(this IBuildHost @this, FilePath path)
+    public static JsonObject LoadJsonObject(this IBuildHost @this, string path)
     {
-        Guard.IsNotNull(path);
+        Guard.IsNotNullOrEmpty(path);
 
-        var fullPath = path.FullPath;
         JsonNode? node;
         try
         {
-            using var stream = SysFile.OpenRead(fullPath);
+            using var stream = SysFile.OpenRead(path);
             node = JsonNode.Parse(
                 stream,
                 new JsonNodeOptions { PropertyNameCaseInsensitive = false },
@@ -78,17 +75,17 @@ public static partial class JsonBuildHostExtensions
         }
         catch (IOException e)
         {
-            return @this.Fail<JsonObject>($"Could not read from {fullPath}: {e.Message}");
+            return @this.Fail<JsonObject>($"Could not read from {path}: {e.Message}");
         }
         catch (JsonException)
         {
-            return @this.Fail<JsonObject>($"{fullPath} does not contain valid JSON.");
+            return @this.Fail<JsonObject>($"{path} does not contain valid JSON.");
         }
 
         return node switch {
-            null => @this.Fail<JsonObject>($"{fullPath} was parsed as JSON null."),
+            null => @this.Fail<JsonObject>($"{path} was parsed as JSON null."),
             JsonObject obj => obj,
-            object other => @this.Fail<JsonObject>($"{fullPath} was parsed as a {other.GetType().Name}, not a {nameof(JsonObject)}."),
+            object other => @this.Fail<JsonObject>($"{path} was parsed as a {other.GetType().Name}, not a {nameof(JsonObject)}."),
         };
     }
 
@@ -98,15 +95,14 @@ public static partial class JsonBuildHostExtensions
     /// <param name="this">The build host.</param>
     /// <param name="json">The JSON object to save.</param>
     /// <param name="path">The path of the file to save <paramref name="json"/> to.</param>
-    public static void SaveJson(this IBuildHost @this, JsonNode json, FilePath path)
+    public static void SaveJson(this IBuildHost @this, JsonNode json, string path)
     {
         Guard.IsNotNull(json);
-        Guard.IsNotNull(path);
+        Guard.IsNotNullOrEmpty(path);
 
-        var fullPath = path.FullPath;
         try
         {
-            using var stream = SysFile.OpenWrite(fullPath);
+            using var stream = SysFile.OpenWrite(path);
             var writerOptions = new JsonWriterOptions
             {
                 Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
@@ -119,7 +115,7 @@ public static partial class JsonBuildHostExtensions
         }
         catch (IOException e)
         {
-            @this.Fail($"Could not write to {fullPath}: {e.Message}");
+            @this.Fail($"Could not write to {path}: {e.Message}");
         }
     }
 
@@ -141,20 +137,19 @@ public static partial class JsonBuildHostExtensions
     /// <para>Replacements are JSON-encoded with <see cref="JavaScriptEncoder.UnsafeRelaxedJsonEscaping"/>,
     /// matching the policy used by <see cref="SaveJson"/>.</para>
     /// </remarks>
-    public static bool RewriteJsonStringValues(this IBuildHost @this, FilePath path, JsonStringValueRewriter rewriter)
+    public static bool RewriteJsonStringValues(this IBuildHost @this, string path, JsonStringValueRewriter rewriter)
     {
-        Guard.IsNotNull(path);
+        Guard.IsNotNullOrEmpty(path);
         Guard.IsNotNull(rewriter);
 
-        var fullPath = path.FullPath;
         byte[] originalBytes;
         try
         {
-            originalBytes = SysFile.ReadAllBytes(fullPath);
+            originalBytes = SysFile.ReadAllBytes(path);
         }
         catch (IOException e)
         {
-            return @this.Fail<bool>($"Could not read from {fullPath}: {e.Message}");
+            return @this.Fail<bool>($"Could not read from {path}: {e.Message}");
         }
 
         // Utf8JsonReader rejects a leading UTF-8 BOM; skip it for parsing but preserve it on rewrite.
@@ -167,7 +162,7 @@ public static partial class JsonBuildHostExtensions
         }
         catch (JsonException)
         {
-            return @this.Fail<bool>($"{fullPath} does not contain valid JSON.");
+            return @this.Fail<bool>($"{path} does not contain valid JSON.");
         }
 
         if (edits.Count == 0)
@@ -196,11 +191,11 @@ public static partial class JsonBuildHostExtensions
 
         try
         {
-            SysFile.WriteAllBytes(fullPath, output.ToArray());
+            SysFile.WriteAllBytes(path, output.ToArray());
         }
         catch (IOException e)
         {
-            @this.Fail($"Could not write to {fullPath}: {e.Message}");
+            @this.Fail($"Could not write to {path}: {e.Message}");
         }
 
         return true;

--- a/src/Buildvana.Core.Json/JsonStringValueRewriter.cs
+++ b/src/Buildvana.Core.Json/JsonStringValueRewriter.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 
-namespace Buildvana.Tool.Utilities;
+namespace Buildvana.Core.Json;
 
 /// <summary>
 /// Computes a replacement for a JSON string value visited during a structural walk of a JSON document.

--- a/src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj
+++ b/src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Buildvana.Core.Abstractions\Buildvana.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\Buildvana.Core.Json\Buildvana.Core.Json.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Buildvana.Tool/Buildvana.Tool.csproj
+++ b/src/Buildvana.Tool/Buildvana.Tool.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Buildvana.Core.Abstractions\Buildvana.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\Buildvana.Core.Json\Buildvana.Core.Json.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Buildvana.Tool/Services/SelfReferenceUpdater.cs
+++ b/src/Buildvana.Tool/Services/SelfReferenceUpdater.cs
@@ -6,8 +6,8 @@ using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 using Buildvana.Core;
+using Buildvana.Core.Json;
 using Buildvana.Tool.Services.Versioning;
-using Buildvana.Tool.Utilities;
 using Cake.Core;
 using Cake.Core.IO;
 using CommunityToolkit.Diagnostics;
@@ -133,7 +133,7 @@ public sealed class SelfReferenceUpdater
         // The expected location of each version string differs by container shape:
         //   - versionPropertyName == null → at depth 2 with path [container, packageId];
         //   - versionPropertyName != null → at depth 3 with path [container, packageId, versionPropertyName].
-        return _host.RewriteJsonStringValues(path, (propertyPath, currentValue) =>
+        return _host.RewriteJsonStringValues(path.FullPath, (propertyPath, currentValue) =>
         {
             if (versionPropertyName is null)
             {

--- a/src/Buildvana.Tool/Services/Versioning/VersionFile.cs
+++ b/src/Buildvana.Tool/Services/Versioning/VersionFile.cs
@@ -3,7 +3,7 @@
 
 using System.Text.Json.Nodes;
 using Buildvana.Core;
-using Buildvana.Tool.Utilities;
+using Buildvana.Core.Json;
 using Cake.Core;
 using Cake.Core.IO;
 using CommunityToolkit.Diagnostics;
@@ -57,7 +57,7 @@ public sealed class VersionFile
         Guard.IsNotNull(host);
 
         var path = new FilePath(VersionJsonPath).MakeAbsolute(context.Environment);
-        var json = host.LoadJsonObject(path);
+        var json = host.LoadJsonObject(path.FullPath);
         var versionStr = host.GetJsonPropertyValue<string>(json, VersionPropertyName, path + " file");
         host.Ensure(VersionSpec.TryParse(versionStr, out var versionSpec), $"{VersionJsonPath} contains invalid version specification '{versionStr}'.");
         var firstUnstableTag = DefaultFirstUnstableTag;
@@ -97,7 +97,7 @@ public sealed class VersionFile
     {
         var newVersion = VersionSpec.ToString();
         var rewritten = _host.RewriteJsonStringValues(
-            Path,
+            Path.FullPath,
             (propertyPath, _) => propertyPath is [VersionPropertyName] ? newVersion : null);
 
         // Load already validated that a top-level string "version" property exists, so a no-op here

--- a/src/Buildvana.Tool/Services/Versioning/VersionService.cs
+++ b/src/Buildvana.Tool/Services/Versioning/VersionService.cs
@@ -3,9 +3,9 @@
 
 using System.Text;
 using Buildvana.Core;
+using Buildvana.Core.Json;
 using Buildvana.Tool.Services.Git;
 using Buildvana.Tool.Services.PublicApiFiles;
-using Buildvana.Tool.Utilities;
 using Cake.Common.Tools.DotNet;
 using Cake.Common.Tools.DotNet.Tool;
 using Cake.Core;


### PR DESCRIPTION
## Summary

Phase 2 of the `Buildvana.Core` extraction effort: pull the JSON helpers (`ParseJsonObject`, `LoadJsonObject`, `SaveJson`, `RewriteJsonStringValues`, `GetJsonPropertyValue`) out of `Buildvana.Tool/Utilities/` into a new internal library `Buildvana.Core.Json`, so both `Buildvana.Tool` and `Buildvana.Sdk.Tasks` can consume them.

- Path parameters change from Cake's `Cake.Core.IO.FilePath` to plain `string`, removing the last host-specific dependency from the helpers.
- `Buildvana.Core.Json` is `IsPackable=false` (inherited from `Common.props`) — it's an internal seam between sibling projects, not a published artifact.
- `Buildvana.Sdk.Tasks` adds a `ProjectReference` to it; the existing `_BinaryProject` / `Publish` mechanism in `Buildvana.Sdk.csproj` automatically copies the resulting `Buildvana.Core.Json.dll` (and the new transitive `CommunityToolkit.Diagnostics.dll`, ~50 KB) into the SDK package's `bin/` folder.
- Call sites in `Buildvana.Tool` (`VersionFile`, `VersionService`, `SelfReferenceUpdater`) switch their `using` to `Buildvana.Core.Json` and pass `path.FullPath` where they previously handed over a `FilePath` instance. Public `FilePath`-typed properties on those services are unchanged.
- `.claude/rules/architecture.md` gains a `Project tiers` section codifying the three-tier convention: `Buildvana.Core.*` internal libraries, `Buildvana.Sdk.*` SDK and components, `Buildvana.Tool` the `bv` CLI. This locks in the naming used here and informs the upcoming `Buildvana.Core.Versioning` rename in #230.

Closes #240. Coordinates with #230 (planned `Buildvana.Versioning` → `Buildvana.Core.Versioning`).

## Test plan

- [x] `dotnet bv build` — zero errors, zero warnings
- [x] `dotnet bv pack` — zero errors, zero warnings
- [x] Verified `Buildvana.Core.Json.dll` is present in `Buildvana.Sdk.<ver>.nupkg` under `bin/`
- [x] Verified `Buildvana.Core.Json.dll` is present in `bv.<ver>.nupkg` under `tools/net10.0/any/`
- [x] All existing `bv` versioning code paths continue to compile against the new string-based signatures