### PR TITLE
Tool refactoring Phase 3: drop Cake.Frosting

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -7,7 +7,7 @@ It consists of an MSBuild SDK working in addition to the SDK specified in projec
 
 Sub-projects under `src/`:
 
-- `Buildvana.Core.Abstractions` — host-agnostic contracts shared by Buildvana libraries (e.g., `IHomeDirectoryProvider`, `IJsonHelper`, `IProcessRunner`) plus `BuildFailedException`. No host references (no Cake, no MSBuild).
+- `Buildvana.Core.Abstractions` — host-agnostic contracts shared by Buildvana libraries (e.g., `IHomeDirectoryProvider`, `IJsonHelper`, `IProcessRunner`) plus `BuildFailedException`. No host references (e.g., MSBuild).
 - `Buildvana.Core.Json` — JSON loading, parsing, saving, and in-place rewriting helpers; reports failures via `BuildFailedException`.
 - `Buildvana.Sdk.Tasks` — compiled MSBuild tasks.
 - `Buildvana.Sdk.SourceGenerators` — Roslyn source generators.
@@ -18,7 +18,7 @@ Sub-projects under `src/`:
 
 Project names follow a three-tier convention:
 
- - `Buildvana.Core.*` — internal libraries shared between sibling projects in this repo. Not packaged. May depend on other `Buildvana.Core.*` libraries and ordinary BCL/NuGet dependencies, but must remain host-agnostic: no host references (Cake, MSBuild, etc.). See "Core tier layout" below for how the tier is structured.
+ - `Buildvana.Core.*` — internal libraries shared between sibling projects in this repo. Not packaged. May depend on other `Buildvana.Core.*` libraries and ordinary BCL/NuGet dependencies, but must remain host-agnostic: no host references (e.g., MSBuild). See "Core tier layout" below for how the tier is structured.
 - `Buildvana.Sdk.*` — the MSBuild SDK and its components (tasks, source generators). Only `Buildvana.Sdk` is packaged; it bundles the others.
 - `Buildvana.Tool` — the `bv` .NET CLI global tool. Packaged as a `dotnet tool`.
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,6 @@
 
   <!-- Run-time dependencies-->
   <ItemGroup>
-    <PackageVersion Include="Cake.Frosting" Version="6.1.0" />
     <PackageVersion Include="CliWrap" Version="3.10.1" />
     <PackageVersion Include="CommunityToolkit.Diagnostics" Version="8.4.2" />
     <PackageVersion Include="Docfx.App" Version="2.78.5" />

--- a/src/Buildvana.Core.Abstractions/BuildFailedException.cs
+++ b/src/Buildvana.Core.Abstractions/BuildFailedException.cs
@@ -10,8 +10,8 @@ namespace Buildvana.Core;
 /// <summary>
 /// <para>The exception that Buildvana libraries throw to fail the build.</para>
 /// <para>Hosts catch this exception at their top-level entry point and translate it
-/// to whatever failure mechanism their runtime expects (e.g., <c>CakeException</c>,
-/// <c>TaskLoggingHelper.LogError</c>, etc.).</para>
+/// to whatever failure mechanism their runtime expects (e.g., <c>TaskLoggingHelper.LogError</c>,
+/// a non-zero process exit code, etc.).</para>
 /// </summary>
 public sealed class BuildFailedException : Exception
 {

--- a/src/Buildvana.Tool/Buildvana.Tool.csproj
+++ b/src/Buildvana.Tool/Buildvana.Tool.csproj
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Frosting" />
     <PackageReference Include="CommunityToolkit.Diagnostics" />
     <PackageReference Include="Docfx.App" />
     <PackageReference Include="JetBrains.Annotations.Sources" />

--- a/src/Buildvana.Tool/Cli/BaseSettings.cs
+++ b/src/Buildvana.Tool/Cli/BaseSettings.cs
@@ -17,7 +17,7 @@ public class BaseSettings : CommandSettings
     /// Gets the requested logging verbosity.
     /// </summary>
     [CommandOption("-v|--verbosity <LEVEL>")]
-    [Description("Logging verbosity. Accepts .NET LogLevel names (Trace/Debug/Information/Warning/Error/Critical/None) or Cake-compat names (Quiet/Minimal/Normal/Verbose/Diagnostic).")]
+    [Description("Logging verbosity. Accepts either Trace/Debug/Information/Warning/Error/Critical/None or Quiet/Minimal/Normal/Verbose/Diagnostic.")]
     public string? Verbosity { get; init; }
 
     /// <summary>

--- a/src/Buildvana.Tool/Services/Solution/HomeDirectorySolutionContextFactory.cs
+++ b/src/Buildvana.Tool/Services/Solution/HomeDirectorySolutionContextFactory.cs
@@ -35,8 +35,7 @@ public sealed class HomeDirectorySolutionContextFactory : ISolutionContextFactor
         var serializer = SolutionSerializers.GetSerializerByMoniker(path)
             ?? throw new BuildFailedException($"No serializer supports solution file '{path}'.");
 
-        // The package's serializers read the file synchronously; sync-waiting on the returned task
-        // is fine here and matches Cake's old eager-load behavior in DotNetService's constructor.
+        // The package's serializers read the file synchronously; sync-waiting on the returned task is fine here.
         var model = serializer.OpenAsync(path, CancellationToken.None).GetAwaiter().GetResult();
 
         return new SolutionContext(path, model);


### PR DESCRIPTION
Closes #237.

## Summary

Phase 3 of #228 — the package-removal step. Cake.Http was already removed in Phase 2 (#253), so this PR removes the remaining `Cake.Frosting` reference and cleans up four stale Cake mentions in adjacent docs and comments. After this lands, the only surviving Cake reference in the repo is the historical `CHANGELOG.md` entry, which the issue explicitly allows to stay.

## Changes

- **Package removal**
  - `src/Buildvana.Tool/Buildvana.Tool.csproj` — drop the `Cake.Frosting` `PackageReference`.
  - `Directory.Packages.props` — drop the matching `PackageVersion`.
- **Stale-mention cleanup** (none of these matched the strict `Cake.` grep, but all read as rot now that the host is gone)
  - `src/Buildvana.Tool/Cli/BaseSettings.cs` — `--verbosity` description no longer calls Quiet/Minimal/Normal/Verbose/Diagnostic "Cake-compat names"; just lists both name sets.
  - `src/Buildvana.Tool/Services/Solution/HomeDirectorySolutionContextFactory.cs` — drop the cross-reference to "Cake's old eager-load behavior in `DotNetService`'s constructor"; keep the why (serializer is synchronous internally).
  - `src/Buildvana.Core.Abstractions/BuildFailedException.cs` — XML doc no longer cites `<c>CakeException</c>` as an example host failure mechanism; replaced with "a non-zero process exit code".
  - `.claude/rules/architecture.md` — drop the "(no Cake, no MSBuild)" / "(Cake, MSBuild, etc.)" examples; MSBuild stays as the lone example since `Buildvana.Sdk.Tasks` still depends on it.

## Acceptance criteria — all met

- [x] `Cake.Frosting` and `Cake.Http` no longer appear in `Directory.Packages.props` or in any `csproj`.
- [x] `dotnet list package --include-transitive` for `Buildvana.Tool` shows no `Cake.*` packages.
- [x] Repo-wide grep for `Cake.` in `src/**/*.cs` returns zero matches.
- [x] `dotnet bv build` self-hosts locally.
- [ ] CI (build-test-pack workflow) succeeds — verified after push.

## Test plan

- [x] `dotnet bv pack` — 0 errors, 0 warnings.
- [x] `inspectcode --swea --severity=WARNING` — 0 results.
- [x] Both packages produced (`Buildvana.Sdk`, `bv`).
- [ ] Self-hosting smoke check after merge & publish (next build cycle).