### PR TITLE
Forward CancellationToken through the build pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING CHANGE**: `bv` no longer forces `-maxcpucount:1` on the `dotnet` invocations of `restore`/`build`/`test`/`pack`. MSBuild now uses its default parallelism unless you forward your own `-m`/`-maxcpucount` switch.
 - **BREAKING CHANGE**: The `-c`/`--configuration` option is no longer parsed by `bv restore`/`build`/`test`/`pack`; for those commands it is just another forwarded argument, passed after the `--` separator. `bv` emits `Release` as an overridable default, so a forwarded `-c`/`-p:Configuration=` still wins (e.g. `bv build -- -c Debug` builds `Debug`). `bv release` keeps `-c`/`--configuration` as a parsed option, since it needs the value to locate build artifacts.
 - `--main-branch` is now a global option: it is accepted at any position on the command line (before or after the subcommand name), appears in the `GLOBAL OPTIONS` section of help, and is honored by the commands that talk to Git.
+- `bv`'s build commands (`clean`, `restore`, `build`, `test`, `pack`) and `release` now observe cancellation. Pressing Ctrl-C (or a host cancelling the operation) stops the pipeline promptly: it stops launching further steps and terminates the running `dotnet` child process instead of waiting for it to finish, then `bv` exits with code 130. Partial build output may be left behind on cancellation; `bv clean` recovers.
 
 ### Bugs fixed in this release
 

--- a/src/Buildvana.Tool/Build/BuildPipeline.cs
+++ b/src/Buildvana.Tool/Build/BuildPipeline.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Buildvana.Tool.CommandLine;
 using Buildvana.Tool.Infrastructure;
@@ -56,9 +57,10 @@ internal sealed class BuildPipeline
     /// </summary>
     /// <param name="last">The last step to run.</param>
     /// <param name="configuration">The MSBuild configuration to build.</param>
+    /// <param name="cancellationToken">A token to observe while running the pipeline. When signalled, the pipeline stops launching further steps and the running <c>dotnet</c> child process is terminated.</param>
     /// <returns>A <see cref="Task"/> representing the ongoing operation.</returns>
-    public Task RunThroughAsync(BuildStep last, string configuration = DefaultConfiguration)
-        => RunRangeAsync(BuildStep.Clean, last, configuration);
+    public Task RunThroughAsync(BuildStep last, string configuration = DefaultConfiguration, CancellationToken cancellationToken = default)
+        => RunRangeAsync(BuildStep.Clean, last, configuration, cancellationToken);
 
     /// <summary>
     /// Runs the pipeline from <paramref name="first"/> through <paramref name="last"/>, inclusive.
@@ -66,13 +68,15 @@ internal sealed class BuildPipeline
     /// <param name="first">The first step to run.</param>
     /// <param name="last">The last step to run.</param>
     /// <param name="configuration">The MSBuild configuration to build.</param>
+    /// <param name="cancellationToken">A token to observe while running the pipeline. When signalled, the pipeline stops launching further steps and the running <c>dotnet</c> child process is terminated.</param>
     /// <returns>A <see cref="Task"/> representing the ongoing operation.</returns>
-    public async Task RunRangeAsync(BuildStep first, BuildStep last, string configuration = DefaultConfiguration)
+    public async Task RunRangeAsync(BuildStep first, BuildStep last, string configuration = DefaultConfiguration, CancellationToken cancellationToken = default)
     {
         Guard.IsLessThanOrEqualTo((int)first, (int)last, nameof(first));
         for (var step = first; step <= last; step++)
         {
-            await RunAsync(step, configuration).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            await RunAsync(step, configuration, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -81,19 +85,20 @@ internal sealed class BuildPipeline
     /// </summary>
     /// <param name="step">The step to run.</param>
     /// <param name="configuration">The MSBuild configuration to build (ignored by <see cref="BuildStep.Clean"/> and <see cref="BuildStep.Restore"/>).</param>
+    /// <param name="cancellationToken">A token to observe while running the step. When signalled, the running <c>dotnet</c> child process is terminated.</param>
     /// <returns>A <see cref="Task"/> representing the ongoing operation.</returns>
-    public Task RunAsync(BuildStep step, string configuration = DefaultConfiguration)
+    public Task RunAsync(BuildStep step, string configuration = DefaultConfiguration, CancellationToken cancellationToken = default)
         => step switch
         {
-            BuildStep.Clean => CleanAsync(),
-            BuildStep.Restore => RestoreAsync(),
-            BuildStep.Build => BuildAsync(configuration),
-            BuildStep.Test => TestAsync(configuration),
-            BuildStep.Pack => PackAsync(configuration),
+            BuildStep.Clean => CleanAsync(cancellationToken),
+            BuildStep.Restore => RestoreAsync(cancellationToken),
+            BuildStep.Build => BuildAsync(configuration, cancellationToken),
+            BuildStep.Test => TestAsync(configuration, cancellationToken),
+            BuildStep.Pack => PackAsync(configuration, cancellationToken),
             _ => ThrowHelper.ThrowArgumentOutOfRangeException<Task>(nameof(step), step, "Unknown build step."),
         };
 
-    private Task CleanAsync()
+    private Task CleanAsync(CancellationToken cancellationToken)
     {
         var logger = _loggerFactory.CreateLogger("Clean");
         FileSystemHelper.DeleteDirectory(_solution.ResolvePath(".vs"), logger);
@@ -103,6 +108,7 @@ internal sealed class BuildPipeline
         FileSystemHelper.DeleteDirectory(_solution.ResolvePath(CommonPaths.TestResults), logger);
         foreach (var project in _solution.Model.SolutionProjects)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var projectDirectory = Path.GetDirectoryName(_solution.ResolveProjectPath(project))!;
             FileSystemHelper.DeleteDirectory(Path.Combine(projectDirectory, "bin"), logger);
             FileSystemHelper.DeleteDirectory(Path.Combine(projectDirectory, "obj"), logger);
@@ -111,15 +117,15 @@ internal sealed class BuildPipeline
         return Task.CompletedTask;
     }
 
-    private Task RestoreAsync()
-        => _dotnet.RestoreSolutionAsync(_solution, _forwardedArgs);
+    private Task RestoreAsync(CancellationToken cancellationToken)
+        => _dotnet.RestoreSolutionAsync(_solution, _forwardedArgs, cancellationToken);
 
-    private Task BuildAsync(string configuration)
-        => _dotnet.BuildSolutionAsync(_solution, configuration, _forwardedArgs, restore: false);
+    private Task BuildAsync(string configuration, CancellationToken cancellationToken)
+        => _dotnet.BuildSolutionAsync(_solution, configuration, _forwardedArgs, restore: false, cancellationToken);
 
-    private Task TestAsync(string configuration)
-        => _dotnet.TestSolutionAsync(_solution, configuration, _forwardedArgs, restore: false, build: false);
+    private Task TestAsync(string configuration, CancellationToken cancellationToken)
+        => _dotnet.TestSolutionAsync(_solution, configuration, _forwardedArgs, restore: false, build: false, cancellationToken);
 
-    private Task PackAsync(string configuration)
-        => _dotnet.PackSolutionAsync(_solution, configuration, _forwardedArgs, restore: false, build: false);
+    private Task PackAsync(string configuration, CancellationToken cancellationToken)
+        => _dotnet.PackSolutionAsync(_solution, configuration, _forwardedArgs, restore: false, build: false, cancellationToken);
 }

--- a/src/Buildvana.Tool/Program.cs
+++ b/src/Buildvana.Tool/Program.cs
@@ -29,6 +29,9 @@ namespace Buildvana.Tool;
 
 internal static class Program
 {
+    // 128 + SIGINT (2): the POSIX convention for a process terminated by Ctrl-C.
+    private const int CancelledExitCode = 130;
+
     public static async Task<int> Main(string[] args)
     {
         var console = AnsiConsole.Console;
@@ -84,8 +87,9 @@ internal static class Program
                 using var cts = new CancellationTokenSource();
                 void OnCancel(object? sender, ConsoleCancelEventArgs e)
                 {
-                    // Suppress the immediate process kill so commands can observe the token; child processes
-                    // still receive their own Ctrl-C from the console and terminate on their own.
+                    // Suppress bv's own immediate termination so the command can observe the token and shut down
+                    // cleanly: the token is forwarded down to the running `dotnet` child, whose process tree is
+                    // then killed.
                     e.Cancel = true;
 
                     // Safe: the handler is removed in the finally below before cts is disposed at end of scope.
@@ -104,6 +108,11 @@ internal static class Program
                     Console.CancelKeyPress -= OnCancel;
                 }
             }
+        }
+        catch (OperationCanceledException)
+        {
+            console.MarkupLine("[yellow]Operation cancelled.[/]");
+            return CancelledExitCode;
         }
         catch (BuildFailedException ex)
         {

--- a/src/Buildvana.Tool/Program.cs
+++ b/src/Buildvana.Tool/Program.cs
@@ -84,7 +84,13 @@ internal static class Program
             var services = BuildServiceProvider(console, globals, parsed, initialLogLevel);
             await using (services.ConfigureAwait(false))
             {
-                using var cts = new CancellationTokenSource();
+                var cts = new CancellationTokenSource();
+
+                // Serializes the Ctrl-C handler with cts disposal in the finally block below. Unsubscribing the
+                // handler does not wait for an in-flight invocation, so without this gate a cts.Cancel() racing
+                // cts.Dispose() could throw ObjectDisposedException on the handler thread.
+                var cancelGate = new Lock();
+                var ctsDisposed = false;
                 void OnCancel(object? sender, ConsoleCancelEventArgs e)
                 {
                     // Suppress bv's own immediate termination so the command can observe the token and shut down
@@ -92,9 +98,17 @@ internal static class Program
                     // then killed.
                     e.Cancel = true;
 
-                    // Safe: the handler is removed in the finally below before cts is disposed at end of scope.
-                    // ReSharper disable once AccessToDisposedClosure
-                    cts.Cancel();
+                    lock (cancelGate)
+                    {
+                        // ReSharper disable once AccessToModifiedClosure
+                        if (ctsDisposed)
+                        {
+                            return;
+                        }
+
+                        // ReSharper disable once AccessToDisposedClosure
+                        cts.Cancel();
+                    }
                 }
 
                 Console.CancelKeyPress += OnCancel;
@@ -106,6 +120,11 @@ internal static class Program
                 finally
                 {
                     Console.CancelKeyPress -= OnCancel;
+                    lock (cancelGate)
+                    {
+                        ctsDisposed = true;
+                        cts.Dispose();
+                    }
                 }
             }
         }

--- a/src/Buildvana.Tool/Services/DotNetService.cs
+++ b/src/Buildvana.Tool/Services/DotNetService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Buildvana.Tool.Configuration;
 using Buildvana.Tool.Infrastructure;
@@ -74,8 +75,9 @@ internal sealed class DotNetService
     /// </summary>
     /// <param name="solution">The solution to restore.</param>
     /// <param name="forwardedArgs">Extra arguments to forward verbatim to the <c>dotnet</c> invocation.</param>
+    /// <param name="cancellationToken">A token that, when signalled, terminates the spawned <c>dotnet</c> child process.</param>
     /// <returns>A <see cref="Task"/> representing the ongoing operation.</returns>
-    public Task RestoreSolutionAsync(SolutionContext solution, IReadOnlyList<string> forwardedArgs)
+    public Task RestoreSolutionAsync(SolutionContext solution, IReadOnlyList<string> forwardedArgs, CancellationToken cancellationToken = default)
     {
         Guard.IsNotNull(solution);
         Guard.IsNotNull(forwardedArgs);
@@ -83,7 +85,7 @@ internal sealed class DotNetService
         List<string> args = ["restore", solution.SolutionPath, "--disable-parallel", "-nologo", "-v", Verbosity];
         args.AddRange(forwardedArgs);
         args.Add(ContinuousIntegrationBuildArg(dotnetTest: false));
-        return RunDotNetAsync(args);
+        return RunDotNetAsync(args, cancellationToken);
     }
 
     /// <summary>
@@ -93,8 +95,9 @@ internal sealed class DotNetService
     /// <param name="configuration">The MSBuild configuration to build.</param>
     /// <param name="forwardedArgs">Extra arguments to forward verbatim to the <c>dotnet</c> invocation.</param>
     /// <param name="restore"><see langword="true"/> to restore NuGet packages before building, <see langword="false"/> otherwise.</param>
+    /// <param name="cancellationToken">A token that, when signalled, terminates the spawned <c>dotnet</c> child process.</param>
     /// <returns>A <see cref="Task"/> representing the ongoing operation.</returns>
-    public Task BuildSolutionAsync(SolutionContext solution, string configuration, IReadOnlyList<string> forwardedArgs, bool restore)
+    public Task BuildSolutionAsync(SolutionContext solution, string configuration, IReadOnlyList<string> forwardedArgs, bool restore, CancellationToken cancellationToken = default)
     {
         Guard.IsNotNull(solution);
         Guard.IsNotNullOrEmpty(configuration);
@@ -108,7 +111,7 @@ internal sealed class DotNetService
 
         args.AddRange(forwardedArgs);
         args.Add(ContinuousIntegrationBuildArg(dotnetTest: false));
-        return RunDotNetAsync(args);
+        return RunDotNetAsync(args, cancellationToken);
     }
 
     /// <summary>
@@ -120,8 +123,9 @@ internal sealed class DotNetService
     /// (reaching the Microsoft.Testing.Platform test applications).</param>
     /// <param name="restore"><see langword="true"/> to restore NuGet packages before testing, <see langword="false"/> otherwise.</param>
     /// <param name="build"><see langword="true"/> to build the solution before testing, <see langword="false"/> otherwise.</param>
+    /// <param name="cancellationToken">A token that, when signalled, terminates the spawned <c>dotnet</c> child process.</param>
     /// <returns>A <see cref="Task"/> representing the ongoing operation.</returns>
-    public async Task TestSolutionAsync(SolutionContext solution, string configuration, IReadOnlyList<string> forwardedArgs, bool restore, bool build)
+    public async Task TestSolutionAsync(SolutionContext solution, string configuration, IReadOnlyList<string> forwardedArgs, bool restore, bool build, CancellationToken cancellationToken = default)
     {
         Guard.IsNotNull(solution);
         Guard.IsNotNullOrEmpty(configuration);
@@ -136,7 +140,7 @@ internal sealed class DotNetService
             // bv-internal MSBuild evaluation: do not forward the user's arguments here, as they may be
             // test-application options that `dotnet msbuild` would reject.
             List<string> probeArgs = ["msbuild", projectPath, "-nologo", "-getProperty:IsTestingPlatformApplication"];
-            var probe = await RunDotNetAsync(probeArgs).ConfigureAwait(false);
+            var probe = await RunDotNetAsync(probeArgs, cancellationToken).ConfigureAwait(false);
 
             if (string.Equals(probe.StandardOutput.Trim(), "true", StringComparison.OrdinalIgnoreCase))
             {
@@ -171,7 +175,7 @@ internal sealed class DotNetService
         args.AddRange(["--coverage", "--coverage-output-format", "cobertura", "--results-directory", CommonPaths.TestResults]);
         args.AddRange(forwardedArgs);
         args.Add(ContinuousIntegrationBuildArg(dotnetTest: true));
-        await RunDotNetAsync(args).ConfigureAwait(false);
+        await RunDotNetAsync(args, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -182,8 +186,9 @@ internal sealed class DotNetService
     /// <param name="forwardedArgs">Extra arguments to forward verbatim to the <c>dotnet</c> invocation.</param>
     /// <param name="restore"><see langword="true"/> to restore NuGet packages before packing, <see langword="false"/> otherwise.</param>
     /// <param name="build"><see langword="true"/> to build the solution before packing, <see langword="false"/> otherwise.</param>
+    /// <param name="cancellationToken">A token that, when signalled, terminates the spawned <c>dotnet</c> child process.</param>
     /// <returns>A <see cref="Task"/> representing the ongoing operation.</returns>
-    public Task PackSolutionAsync(SolutionContext solution, string configuration, IReadOnlyList<string> forwardedArgs, bool restore, bool build)
+    public Task PackSolutionAsync(SolutionContext solution, string configuration, IReadOnlyList<string> forwardedArgs, bool restore, bool build, CancellationToken cancellationToken = default)
     {
         Guard.IsNotNull(solution);
         Guard.IsNotNullOrEmpty(configuration);
@@ -202,15 +207,16 @@ internal sealed class DotNetService
 
         args.AddRange(forwardedArgs);
         args.Add(ContinuousIntegrationBuildArg(dotnetTest: false));
-        return RunDotNetAsync(args);
+        return RunDotNetAsync(args, cancellationToken);
     }
 
     /// <summary>
     /// Asynchronously pushes all produced NuGet packages to the appropriate NuGet server.
     /// </summary>
     /// <param name="artifactsPath">The path of the directory containing the produced <c>*.nupkg</c> files.</param>
+    /// <param name="cancellationToken">A token that, when signalled, terminates the spawned <c>dotnet</c> child process.</param>
     /// <returns>A <see cref="Task"/> representing the ongoing operation.</returns>
-    public async Task NuGetPushAllAsync(string artifactsPath)
+    public async Task NuGetPushAllAsync(string artifactsPath, CancellationToken cancellationToken = default)
     {
         Guard.IsNotNullOrEmpty(artifactsPath);
         var packages = FileSystemHelper.EnumerateFiles(artifactsPath, "*.nupkg").ToArray();
@@ -231,7 +237,8 @@ internal sealed class DotNetService
             await _processRunner
                 .RunAsync(
                     DotNetMuxer,
-                    ["nuget", "push", path, "--source", target.Source, "--api-key", target.ApiKey, "--skip-duplicate", "--force-english-output"])
+                    ["nuget", "push", path, "--source", target.Source, "--api-key", target.ApiKey, "--skip-duplicate", "--force-english-output"],
+                    cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         }
     }
@@ -244,6 +251,6 @@ internal sealed class DotNetService
         return $"{prefix}ContinuousIntegrationBuild={(_server.IsCloudBuild ? "true" : "false")}";
     }
 
-    private Task<ProcessResult> RunDotNetAsync(IEnumerable<string> args)
-        => _processRunner.RunAsync(DotNetMuxer, args);
+    private Task<ProcessResult> RunDotNetAsync(IEnumerable<string> args, CancellationToken cancellationToken = default)
+        => _processRunner.RunAsync(DotNetMuxer, args, cancellationToken: cancellationToken);
 }

--- a/src/Buildvana.Tool/Subcommands/BuildCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/BuildCommand.cs
@@ -15,7 +15,7 @@ internal sealed class BuildCommand(BuildPipeline pipeline) : IBvCommand
 {
     public async Task<int> ExecuteAsync(CancellationToken cancellationToken)
     {
-        await pipeline.RunThroughAsync(BuildStep.Build).ConfigureAwait(false);
+        await pipeline.RunThroughAsync(BuildStep.Build, cancellationToken: cancellationToken).ConfigureAwait(false);
         return 0;
     }
 }

--- a/src/Buildvana.Tool/Subcommands/CleanCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/CleanCommand.cs
@@ -15,7 +15,7 @@ internal sealed class CleanCommand(BuildPipeline pipeline) : IBvCommand
 {
     public async Task<int> ExecuteAsync(CancellationToken cancellationToken)
     {
-        await pipeline.RunThroughAsync(BuildStep.Clean).ConfigureAwait(false);
+        await pipeline.RunThroughAsync(BuildStep.Clean, cancellationToken: cancellationToken).ConfigureAwait(false);
         return 0;
     }
 }

--- a/src/Buildvana.Tool/Subcommands/PackCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/PackCommand.cs
@@ -15,7 +15,7 @@ internal sealed class PackCommand(BuildPipeline pipeline) : IBvCommand
 {
     public async Task<int> ExecuteAsync(CancellationToken cancellationToken)
     {
-        await pipeline.RunThroughAsync(BuildStep.Pack).ConfigureAwait(false);
+        await pipeline.RunThroughAsync(BuildStep.Pack, cancellationToken: cancellationToken).ConfigureAwait(false);
         return 0;
     }
 }

--- a/src/Buildvana.Tool/Subcommands/ReleaseCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/ReleaseCommand.cs
@@ -34,7 +34,7 @@ internal sealed class ReleaseCommand(IServiceProvider services, ReleaseSettings 
         var artifactsPath = Path.Combine(CommonPaths.AllArtifacts, configuration);
 
         // Verification pass (Clean→Test), mirroring today's [IsDependentOn(TestTask)] chain.
-        await pipeline.RunThroughAsync(BuildStep.Test, configuration).ConfigureAwait(false);
+        await pipeline.RunThroughAsync(BuildStep.Test, configuration, cancellationToken).ConfigureAwait(false);
 
         var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger("Release");
         var home = services.GetRequiredService<IHomeDirectoryProvider>();
@@ -170,7 +170,7 @@ internal sealed class ReleaseCommand(IServiceProvider services, ReleaseSettings 
             BuildFailedException.ThrowIfNot(!git.TagExists(version.CurrentStr), $"Tag '{version.CurrentStr}' already exists in repository.");
 
             // Artifact pass (Restore→Pack, no Clean): rebuild against the resolved version and make artifacts.
-            await pipeline.RunRangeAsync(BuildStep.Restore, BuildStep.Pack, configuration).ConfigureAwait(false);
+            await pipeline.RunRangeAsync(BuildStep.Restore, BuildStep.Pack, configuration, cancellationToken).ConfigureAwait(false);
 
             if (changelogUpdated)
             {
@@ -220,7 +220,7 @@ internal sealed class ReleaseCommand(IServiceProvider services, ReleaseSettings 
             release.PushUpdates();
 
             // Publish NuGet packages
-            await dotnet.NuGetPushAllAsync(artifactsPath).ConfigureAwait(false);
+            await dotnet.NuGetPushAllAsync(artifactsPath, cancellationToken).ConfigureAwait(false);
 
             // Gather build assets from Buildvana.Sdk release asset lists
             logger.LogInformation("Reading release asset lists...");

--- a/src/Buildvana.Tool/Subcommands/RestoreCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/RestoreCommand.cs
@@ -15,7 +15,7 @@ internal sealed class RestoreCommand(BuildPipeline pipeline) : IBvCommand
 {
     public async Task<int> ExecuteAsync(CancellationToken cancellationToken)
     {
-        await pipeline.RunThroughAsync(BuildStep.Restore).ConfigureAwait(false);
+        await pipeline.RunThroughAsync(BuildStep.Restore, cancellationToken: cancellationToken).ConfigureAwait(false);
         return 0;
     }
 }

--- a/src/Buildvana.Tool/Subcommands/TestCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/TestCommand.cs
@@ -15,7 +15,7 @@ internal sealed class TestCommand(BuildPipeline pipeline) : IBvCommand
 {
     public async Task<int> ExecuteAsync(CancellationToken cancellationToken)
     {
-        await pipeline.RunThroughAsync(BuildStep.Test).ConfigureAwait(false);
+        await pipeline.RunThroughAsync(BuildStep.Test, cancellationToken: cancellationToken).ConfigureAwait(false);
         return 0;
     }
 }


### PR DESCRIPTION
## Summary

`bv` subcommands received a `CancellationToken` but discarded it, so Ctrl+C could not
interrupt an in-flight `restore`/`build`/`test`/`pack` — the spawned `dotnet` ran to
completion on its own. This threads the token end-to-end.

- `BuildPipeline` (`RunThroughAsync`/`RunRangeAsync`/`RunAsync` + step methods) and
  `DotNetService` (the five public methods + `RunDotNetAsync`) now take and forward a
  `CancellationToken` to the process runner. `RunRangeAsync` stops launching further
  steps once the token is signalled; `CleanAsync` honors it between per-project deletions.
- On cancellation, CliWrap kills the entire `dotnet` process tree (no orphaned children)
  and throws `OperationCanceledException`; `Program` maps that to exit code `130`.
- `DocFxService` (in-process DocFX API) and `GitService` (LibGit2Sharp) spawn no child
  processes, so they're untouched.

## Test plan

- [x] `dotnet bv pack` — clean/restore/build/test/pack all green; artifacts produced.
- [x] ReSharper `inspectcode --severity=WARNING` — 0 results.
- [ ] Manual: Ctrl+C during `bv build` terminates `dotnet` promptly and `bv` exits 130
      *(not exercised — interactive; code path + CliWrap contract verified instead)*.

Closes #282