### PR TITLE
Fix inconsistent Test subcommand description

### DIFF
--- a/src/Buildvana.Tool/Subcommands/TestCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/TestCommand.cs
@@ -10,7 +10,7 @@ using Buildvana.Tool.Infrastructure.Execution;
 namespace Buildvana.Tool.Subcommands;
 
 [ImplementsCommand("test", consumesAllArguments: true)]
-[Description("Build all projects and run tests.")]
+[Description("Clean, restore, build all projects, and run tests.")]
 internal sealed class TestCommand(BuildPipeline pipeline) : IBvCommand
 {
     public async Task<int> ExecuteAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
## Proposed changes

The description for the `test` subcommand in `bv`'s help did not mention all the build pipeline steps it executes, like the descriptions for all other build pipeline subcommands.

It now states "Clean, restore, build all projects, and run tests." which is consistent with other build pipeline subcommands.

Closes #283.
