### PR TITLE
Add Buildvana.Core.Versioning shared library (Versioning Phase 4)

### DIFF
--- a/Buildvana.slnx
+++ b/Buildvana.slnx
@@ -44,6 +44,7 @@
     <Project Path="src/Buildvana.Core.Json/Buildvana.Core.Json.csproj" />
     <Project Path="src/Buildvana.Core.JsonSchema/Buildvana.Core.JsonSchema.csproj" />
     <Project Path="src/Buildvana.Core.Process/Buildvana.Core.Process.csproj" />
+    <Project Path="src/Buildvana.Core.Versioning/Buildvana.Core.Versioning.csproj" />
     <Project Path="src/Buildvana.Sdk.SourceGenerators/Buildvana.Sdk.SourceGenerators.csproj" />
     <Project Path="src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj" />
     <Project Path="src/Buildvana.Sdk/Buildvana.Sdk.csproj" />
@@ -53,6 +54,7 @@
     <File Path="tests/Common.targets" />
     <Project Path="tests/Buildvana.Core.Configuration.Tests/Buildvana.Core.Configuration.Tests.csproj" />
     <Project Path="tests/Buildvana.Core.JsonSchema.Tests/Buildvana.Core.JsonSchema.Tests.csproj" />
+    <Project Path="tests/Buildvana.Core.Versioning.Tests/Buildvana.Core.Versioning.Tests.csproj" />
     <Project Path="tests/Buildvana.Tool.Tests/Buildvana.Tool.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Buildvana.Core.Versioning/Buildvana.Core.Versioning.csproj
+++ b/src/Buildvana.Core.Versioning/Buildvana.Core.Versioning.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Buildvana versioning</Title>
+    <Description>Host-agnostic version computation: the current-version.json model, semantic-version calculation from git height, and public-release branch matching. Reports malformed input via standard exceptions.</Description>
+    <TargetFramework>$(StandardTfm)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Diagnostics" />
+    <PackageReference Include="NuGet.Versioning" />
+  </ItemGroup>
+
+</Project>

--- a/src/Buildvana.Core.Versioning/CalculatedVersion.cs
+++ b/src/Buildvana.Core.Versioning/CalculatedVersion.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using NuGet.Versioning;
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Represents the result of a version computation performed by <see cref="VersionCalculator.Compute"/>.
+/// </summary>
+/// <param name="SemanticVersion">The computed semantic version.</param>
+/// <param name="CurrentStr">The normalized SemVer 2.0 string form of <paramref name="SemanticVersion"/>.</param>
+/// <param name="IsPublicRelease">A value indicating whether the build is a public release, i.e. the current branch
+/// matches one of the configured public-release patterns.</param>
+/// <param name="IsPrerelease">A value indicating whether the computed version is a prerelease.</param>
+public sealed record CalculatedVersion(
+    SemanticVersion SemanticVersion,
+    string CurrentStr,
+    bool IsPublicRelease,
+    bool IsPrerelease);

--- a/src/Buildvana.Core.Versioning/VersionCalculator.cs
+++ b/src/Buildvana.Core.Versioning/VersionCalculator.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using CommunityToolkit.Diagnostics;
+using NuGet.Versioning;
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Computes a semantic version from version-file data, the git height, the current branch, and release policy.
+/// </summary>
+public static class VersionCalculator
+{
+    /// <summary>
+    /// Computes the version to build.
+    /// </summary>
+    /// <param name="fileData">The data parsed from <c>current-version.json</c>.</param>
+    /// <param name="height">The git height (number of commits since the version was last changed); must be non-negative.</param>
+    /// <param name="branchName">The short name of the current branch, or the empty string when HEAD is detached.</param>
+    /// <param name="publicReleaseBranches">The patterns identifying public-release branches, matched against
+    /// <paramref name="branchName"/>. Callers should compile these with <see cref="RegexOptions.CultureInvariant"/>
+    /// and a match timeout; the patterns are expected to carry their own anchors.</param>
+    /// <param name="prereleaseTag">The prerelease tag to apply when <paramref name="fileData"/> denotes a prerelease;
+    /// required (non-empty) in that case, ignored otherwise.</param>
+    /// <returns>A <see cref="CalculatedVersion"/> describing the computed version.</returns>
+    /// <exception cref="ArgumentNullException">A reference argument is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="height"/> is negative.</exception>
+    /// <exception cref="ArgumentException"><paramref name="fileData"/> denotes a prerelease but
+    /// <paramref name="prereleaseTag"/> is <see langword="null"/> or empty.</exception>
+    /// <exception cref="RegexMatchTimeoutException">A pattern in <paramref name="publicReleaseBranches"/> exceeded its match timeout.</exception>
+    public static CalculatedVersion Compute(
+        VersionFileData fileData,
+        int height,
+        string branchName,
+        IReadOnlyList<Regex> publicReleaseBranches,
+        string? prereleaseTag)
+    {
+        Guard.IsNotNull(fileData);
+        Guard.IsGreaterThanOrEqualTo(height, 0);
+        Guard.IsNotNull(branchName);
+        Guard.IsNotNull(publicReleaseBranches);
+
+        SemanticVersion semanticVersion;
+        if (fileData.Prerelease)
+        {
+            if (string.IsNullOrEmpty(prereleaseTag))
+            {
+                throw new ArgumentException(
+                    "A prerelease tag is required to compute a prerelease version, but none was provided.",
+                    nameof(prereleaseTag));
+            }
+
+            semanticVersion = new SemanticVersion(fileData.Major, fileData.Minor, height, prereleaseTag);
+        }
+        else
+        {
+            semanticVersion = new SemanticVersion(fileData.Major, fileData.Minor, height);
+        }
+
+        var currentStr = semanticVersion.ToNormalizedString();
+        var isPublicRelease = publicReleaseBranches.Any(pattern => pattern.IsMatch(branchName));
+        return new CalculatedVersion(semanticVersion, currentStr, isPublicRelease, semanticVersion.IsPrerelease);
+    }
+}

--- a/src/Buildvana.Core.Versioning/VersionFileData.cs
+++ b/src/Buildvana.Core.Versioning/VersionFileData.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Text.Json;
+using CommunityToolkit.Diagnostics;
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Represents the immutable data parsed from a <c>current-version.json</c> file
+/// (<c>{ "major": &lt;int&gt;, "minor": &lt;int&gt;, "prerelease": &lt;bool&gt; }</c>).
+/// </summary>
+/// <param name="Major">The major version component.</param>
+/// <param name="Minor">The minor version component.</param>
+/// <param name="Prerelease">A value indicating whether the version is a prerelease.</param>
+/// <remarks>
+/// <para>The <c>current-version.json</c> file holds the version <em>value</em>; release <em>policy</em>
+/// (public-release branches, prerelease tag, assembly-version precision) lives in <c>buildvana.json</c>.</para>
+/// <para>This type does not read the file from disk. Callers are responsible for reading the file content and
+/// for <strong>failing loudly when the file is absent</strong>: a missing <c>current-version.json</c> must be
+/// treated as an error, never silently defaulted.</para>
+/// </remarks>
+public sealed record VersionFileData(int Major, int Minor, bool Prerelease)
+{
+    /// <summary>
+    /// Parses a <see cref="VersionFileData"/> from the textual content of a <c>current-version.json</c> file.
+    /// </summary>
+    /// <param name="json">The JSON content to parse.</param>
+    /// <returns>The parsed <see cref="VersionFileData"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="json"/> is <see langword="null"/>.</exception>
+    /// <exception cref="FormatException">
+    /// <paramref name="json"/> is not a JSON object, is missing a required property, or has a property of the wrong
+    /// type or value (<c>major</c> and <c>minor</c> must be non-negative integers, <c>prerelease</c> a boolean).
+    /// </exception>
+    public static VersionFileData Parse(string json)
+    {
+        Guard.IsNotNull(json);
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(json);
+        }
+        catch (JsonException exception)
+        {
+            throw new FormatException("current-version.json is not valid JSON.", exception);
+        }
+
+        using (document)
+        {
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                throw new FormatException("current-version.json must contain a JSON object.");
+            }
+
+            var major = GetNonNegativeInt32(root, "major");
+            var minor = GetNonNegativeInt32(root, "minor");
+            var prerelease = GetBoolean(root, "prerelease");
+            return new VersionFileData(major, minor, prerelease);
+        }
+    }
+
+    private static int GetNonNegativeInt32(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var element))
+        {
+            throw new FormatException($"current-version.json is missing the required '{propertyName}' property.");
+        }
+
+        if (element.ValueKind == JsonValueKind.Number && element.TryGetInt32(out var value) && value >= 0)
+        {
+            return value;
+        }
+
+        throw new FormatException($"current-version.json property '{propertyName}' must be a non-negative integer.");
+    }
+
+    private static bool GetBoolean(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var element))
+        {
+            throw new FormatException($"current-version.json is missing the required '{propertyName}' property.");
+        }
+
+        return element.ValueKind switch {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => throw new FormatException($"current-version.json property '{propertyName}' must be a boolean."),
+        };
+    }
+}

--- a/src/Buildvana.Core.Versioning/VersionSpec.cs
+++ b/src/Buildvana.Core.Versioning/VersionSpec.cs
@@ -6,12 +6,12 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text.RegularExpressions;
 
-namespace Buildvana.Tool.Services.Versioning;
+namespace Buildvana.Core.Versioning;
 
 /// <summary>
 /// Represents a Major.Minor[-Tag] version as found in version.json.
 /// </summary>
-internal sealed partial record VersionSpec
+public sealed partial record VersionSpec
 {
     private static readonly Regex VersionSpecRegex = GetVersionSpecRegex();
 

--- a/src/Buildvana.Core.Versioning/VersionSpecChange.cs
+++ b/src/Buildvana.Core.Versioning/VersionSpecChange.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-namespace Buildvana.Tool.Services.Versioning;
+namespace Buildvana.Core.Versioning;
 
 /// <summary>
 /// Specifies how to modify the version specification upon publishing a release.
 /// </summary>
-internal enum VersionSpecChange
+public enum VersionSpecChange
 {
     /// <summary>
     /// Do not force a version increment; do not modify the unstable tag.

--- a/src/Buildvana.Tool/Buildvana.Tool.csproj
+++ b/src/Buildvana.Tool/Buildvana.Tool.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\Buildvana.Core.HomeDirectory\Buildvana.Core.HomeDirectory.csproj" />
     <ProjectReference Include="..\Buildvana.Core.Json\Buildvana.Core.Json.csproj" />
     <ProjectReference Include="..\Buildvana.Core.Process\Buildvana.Core.Process.csproj" />
+    <ProjectReference Include="..\Buildvana.Core.Versioning\Buildvana.Core.Versioning.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Buildvana.Tool/Services/Versioning/VersionFile.cs
+++ b/src/Buildvana.Tool/Services/Versioning/VersionFile.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Nodes;
 using Buildvana.Core;
 using Buildvana.Core.HomeDirectory;
 using Buildvana.Core.Json;
+using Buildvana.Core.Versioning;
 using CommunityToolkit.Diagnostics;
 
 namespace Buildvana.Tool.Services.Versioning;

--- a/src/Buildvana.Tool/Services/Versioning/VersionService.cs
+++ b/src/Buildvana.Tool/Services/Versioning/VersionService.cs
@@ -5,6 +5,7 @@ using Buildvana.Core;
 using Buildvana.Core.ConsoleOutput;
 using Buildvana.Core.Json;
 using Buildvana.Core.Process;
+using Buildvana.Core.Versioning;
 using Buildvana.Tool.Services.Git;
 using Buildvana.Tool.Services.PublicApiFiles;
 using CommunityToolkit.Diagnostics;

--- a/src/Buildvana.Tool/Subcommands/ReleaseCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/ReleaseCommand.cs
@@ -13,6 +13,7 @@ using Buildvana.Core.Configuration;
 using Buildvana.Core.ConsoleOutput;
 using Buildvana.Core.HomeDirectory;
 using Buildvana.Core.Json;
+using Buildvana.Core.Versioning;
 using Buildvana.Tool.Build;
 using Buildvana.Tool.Infrastructure;
 using Buildvana.Tool.Infrastructure.Execution;

--- a/src/Buildvana.Tool/Subcommands/ReleaseSettings.cs
+++ b/src/Buildvana.Tool/Subcommands/ReleaseSettings.cs
@@ -7,9 +7,9 @@ using System.ComponentModel;
 using System.Text.RegularExpressions;
 using Buildvana.Core;
 using Buildvana.Core.Configuration;
+using Buildvana.Core.Versioning;
 using Buildvana.Tool.CommandLine;
 using Buildvana.Tool.Services;
-using Buildvana.Tool.Services.Versioning;
 using CommunityToolkit.Diagnostics;
 
 namespace Buildvana.Tool.Subcommands;

--- a/tests/Buildvana.Core.Versioning.Tests/Buildvana.Core.Versioning.Tests.csproj
+++ b/tests/Buildvana.Core.Versioning.Tests/Buildvana.Core.Versioning.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(StandardTfm)</TargetFramework>
+    <ClsCompliant>false</ClsCompliant>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Buildvana.Core.Versioning\Buildvana.Core.Versioning.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Buildvana.Core.Versioning.Tests/VersionCalculatorTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersionCalculatorTests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+using Buildvana.Core.Versioning;
+using NuGet.Versioning;
+
+internal sealed class VersionCalculatorTests
+{
+    [Test]
+    public async Task Compute_StableVersion_BuildsMajorMinorHeight()
+    {
+        var result = Compute(new VersionFileData(2, 1, false), height: 7, branchName: "main");
+        await Assert.That(result.CurrentStr).IsEqualTo("2.1.7");
+        await Assert.That(result.SemanticVersion).IsEqualTo(new SemanticVersion(2, 1, 7));
+        await Assert.That(result.IsPrerelease).IsFalse();
+    }
+
+    [Test]
+    public async Task Compute_PrereleaseVersion_AppendsTagToHeight()
+    {
+        var result = Compute(new VersionFileData(2, 0, true), height: 3, prereleaseTag: "preview");
+        await Assert.That(result.CurrentStr).IsEqualTo("2.0.3-preview");
+        await Assert.That(result.IsPrerelease).IsTrue();
+    }
+
+    [Test]
+    public async Task Compute_PrereleaseWithoutTag_Throws()
+    {
+        await Assert.That(() => Compute(new VersionFileData(1, 0, true))).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Compute_NegativeHeight_Throws()
+    {
+        await Assert.That(() => Compute(new VersionFileData(1, 0, false), height: -1))
+            .Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Compute_BranchMatchesAnyPattern_IsPublicReleaseTrue()
+    {
+        IReadOnlyList<Regex> branches = [new Regex("^main$"), new Regex(@"^v\d+\.\d+$")];
+        var result = Compute(new VersionFileData(2, 0, false), branchName: "v2.0", publicReleaseBranches: branches);
+        await Assert.That(result.IsPublicRelease).IsTrue();
+    }
+
+    [Test]
+    public async Task Compute_BranchMatchesNoPattern_IsPublicReleaseFalse()
+    {
+        IReadOnlyList<Regex> branches = [new Regex("^main$")];
+        var result = Compute(new VersionFileData(2, 0, false), branchName: "topic", publicReleaseBranches: branches);
+        await Assert.That(result.IsPublicRelease).IsFalse();
+    }
+
+    [Test]
+    public async Task Compute_EmptyBranchList_IsPublicReleaseFalse()
+    {
+        var result = Compute(new VersionFileData(2, 0, false), branchName: "main");
+        await Assert.That(result.IsPublicRelease).IsFalse();
+    }
+
+    [Test]
+    public async Task Compute_DetachedHead_IsPublicReleaseFalse()
+    {
+        IReadOnlyList<Regex> branches = [new Regex("^main$")];
+        var result = Compute(
+            new VersionFileData(2, 0, false),
+            branchName: string.Empty,
+            publicReleaseBranches: branches);
+        await Assert.That(result.IsPublicRelease).IsFalse();
+    }
+
+    private static CalculatedVersion Compute(
+        VersionFileData fileData,
+        int height = 0,
+        string branchName = "",
+        IReadOnlyList<Regex>? publicReleaseBranches = null,
+        string? prereleaseTag = null)
+        => VersionCalculator.Compute(fileData, height, branchName, publicReleaseBranches ?? [], prereleaseTag);
+}

--- a/tests/Buildvana.Core.Versioning.Tests/VersionFileDataTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersionFileDataTests.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core.Versioning;
+
+internal sealed class VersionFileDataTests
+{
+    [Test]
+    public async Task Parse_ValidStableVersion_ParsesAllFields()
+    {
+        var data = VersionFileData.Parse("""{ "major": 2, "minor": 1, "prerelease": false }""");
+        await Assert.That(data.Major).IsEqualTo(2);
+        await Assert.That(data.Minor).IsEqualTo(1);
+        await Assert.That(data.Prerelease).IsFalse();
+    }
+
+    [Test]
+    public async Task Parse_ValidPrerelease_SetsPrereleaseTrue()
+    {
+        var data = VersionFileData.Parse("""{ "major": 0, "minor": 0, "prerelease": true }""");
+        await Assert.That(data.Prerelease).IsTrue();
+    }
+
+    [Test]
+    public async Task Parse_NotValidJson_Throws()
+    {
+        await Assert.That(() => VersionFileData.Parse("{ not json")).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task Parse_NotAnObject_Throws()
+    {
+        await Assert.That(() => VersionFileData.Parse("42")).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task Parse_MissingMajor_Throws()
+    {
+        const string json = """{ "minor": 0, "prerelease": false }""";
+        await Assert.That(() => VersionFileData.Parse(json)).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task Parse_MissingPrerelease_Throws()
+    {
+        const string json = """{ "major": 0, "minor": 0 }""";
+        await Assert.That(() => VersionFileData.Parse(json)).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task Parse_MajorWrongType_Throws()
+    {
+        const string json = """{ "major": "2", "minor": 0, "prerelease": false }""";
+        await Assert.That(() => VersionFileData.Parse(json)).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task Parse_NegativeMajor_Throws()
+    {
+        const string json = """{ "major": -1, "minor": 0, "prerelease": false }""";
+        await Assert.That(() => VersionFileData.Parse(json)).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task Parse_NonIntegerMajor_Throws()
+    {
+        const string json = """{ "major": 2.5, "minor": 0, "prerelease": false }""";
+        await Assert.That(() => VersionFileData.Parse(json)).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task Parse_PrereleaseWrongType_Throws()
+    {
+        const string json = """{ "major": 0, "minor": 0, "prerelease": "yes" }""";
+        await Assert.That(() => VersionFileData.Parse(json)).Throws<FormatException>();
+    }
+}

--- a/tests/Buildvana.Core.Versioning.Tests/VersionSpecTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersionSpecTests.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core.Versioning;
+
+internal sealed class VersionSpecTests
+{
+    [Test]
+    public async Task TryParse_ValidStable_ParsesComponents()
+    {
+        var parsed = VersionSpec.TryParse("2.0", out var spec);
+        await Assert.That(parsed).IsTrue();
+        await Assert.That(spec!.Major).IsEqualTo(2);
+        await Assert.That(spec.Minor).IsEqualTo(0);
+        await Assert.That(spec.HasTag).IsFalse();
+    }
+
+    [Test]
+    public async Task TryParse_WithVPrefixAndTag_ParsesComponents()
+    {
+        var parsed = VersionSpec.TryParse("v1.5-preview", out var spec);
+        await Assert.That(parsed).IsTrue();
+        await Assert.That(spec!.Major).IsEqualTo(1);
+        await Assert.That(spec.Minor).IsEqualTo(5);
+        await Assert.That(spec.Tag).IsEqualTo("preview");
+    }
+
+    [Test]
+    public async Task TryParse_InvalidString_ReturnsFalse()
+    {
+        await Assert.That(VersionSpec.TryParse("not-a-version", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task ToString_RoundTripsTag()
+    {
+        _ = VersionSpec.TryParse("3.4-beta", out var spec);
+        await Assert.That(spec!.ToString()).IsEqualTo("3.4-beta");
+    }
+
+    [Test]
+    public async Task ApplyChange_Major_BumpsMajorResetsMinorAddsTag()
+    {
+        _ = VersionSpec.TryParse("2.3", out var spec);
+        var (result, changed) = spec!.ApplyChange(VersionSpecChange.Major, "preview");
+        await Assert.That(changed).IsTrue();
+        await Assert.That(result.ToString()).IsEqualTo("3.0-preview");
+    }
+
+    [Test]
+    public async Task ApplyChange_StableWhenAlreadyStable_ReportsNoChange()
+    {
+        _ = VersionSpec.TryParse("2.3", out var spec);
+        var (result, changed) = spec!.ApplyChange(VersionSpecChange.Stable, "preview");
+        await Assert.That(changed).IsFalse();
+        await Assert.That(result).IsEqualTo(spec);
+    }
+}

--- a/tests/Buildvana.Tool.Tests/ReleaseSettingsTests.cs
+++ b/tests/Buildvana.Tool.Tests/ReleaseSettingsTests.cs
@@ -3,8 +3,8 @@
 
 using Buildvana.Core;
 using Buildvana.Core.Configuration;
+using Buildvana.Core.Versioning;
 using Buildvana.Tool.Services;
-using Buildvana.Tool.Services.Versioning;
 using Buildvana.Tool.Subcommands;
 
 internal sealed class ReleaseSettingsTests


### PR DESCRIPTION
Closes #271. Part of #267.

## Summary
Stands up a new host-agnostic `Buildvana.Core.Versioning` library holding the pure version logic that native versioning (Phases 5–6) will build on. The library is added and unit-tested but **not yet wired into the live version-computation path** — `bv` still computes versions via `nbgv`, so there is **no behavior change** in this phase.

## Changes
- **New `src/Buildvana.Core.Versioning/`** (`$(StandardTfm)`; depends only on `NuGet.Versioning` + `CommunityToolkit.Diagnostics`):
  - `VersionSpec` and `VersionSpecChange` moved verbatim from `Buildvana.Tool` (recorded as renames; namespace → `Buildvana.Core.Versioning`, made `public`).
  - `VersionFileData` — immutable model of `current-version.json` (`{ major, minor, prerelease }`) with a strict `Parse(string)` rejecting malformed input (`FormatException`). Parse-only; "fail loudly if the file is absent" is documented as a caller contract.
  - `VersionCalculator.Compute(...)` — builds `M.m.{height}[-tag]` from version-file data + git height + branch; `IsPublicRelease` = branch matches any public-release pattern.
  - `CalculatedVersion` — result record (`SemanticVersion`, `CurrentStr`, `IsPublicRelease`, `IsPrerelease`).
- **`Buildvana.Tool`** references the new library; `using`s updated where the two types moved. No logic change.
- **New `tests/Buildvana.Core.Versioning.Tests/`** (TUnit, 24 tests): version-string construction, regex matching (empty list, detached HEAD), `current-version.json` parsing (valid/malformed), plus `VersionSpec` (previously untested).

## Notes / decisions
- Named `Buildvana.Core.Versioning` (Core-tier convention) rather than the issue's `Buildvana.Versioning`.
- `VersionSpecChange` moved alongside `VersionSpec` (`ApplyChange` depends on it).
- `Compute` takes pre-compiled `IReadOnlyList<Regex>`; callers own compilation/timeout/error-translation (mirrors `ReleaseSettings`).
- Guard added: a prerelease `VersionFileData` with an empty `prereleaseTag` throws, so a prerelease can't silently degrade to a stable version.

## Acceptance criteria
- [x] Library builds cleanly; `VersionSpec` no longer exists under `Buildvana.Tool`.
- [x] Unit tests for `VersionCalculator` and `VersionFileData` pass.
- [x] `bv` behavior unchanged (NBGV still in use).
- [x] CHANGELOG: internal-only — no public entry.

## Verification
- `dotnet bv pack` → success (Release artifacts produced).
- `dotnet build -c Release` → 0 warnings / 0 errors.
- ReSharper `inspectcode --severity=WARNING` → 0 results.
- Tests: Versioning 24/24, Tool 66/66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)