### PR TITLE
Add the Buildvana.Core.Versioning library

### DIFF
--- a/Buildvana.slnx
+++ b/Buildvana.slnx
@@ -44,6 +44,7 @@
     <Project Path="src/Buildvana.Core.Json/Buildvana.Core.Json.csproj" />
     <Project Path="src/Buildvana.Core.JsonSchema/Buildvana.Core.JsonSchema.csproj" />
     <Project Path="src/Buildvana.Core.Process/Buildvana.Core.Process.csproj" />
+    <Project Path="src/Buildvana.Core.Versioning/Buildvana.Core.Versioning.csproj" />
     <Project Path="src/Buildvana.Sdk.SourceGenerators/Buildvana.Sdk.SourceGenerators.csproj" />
     <Project Path="src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj" />
     <Project Path="src/Buildvana.Sdk/Buildvana.Sdk.csproj" />
@@ -53,6 +54,7 @@
     <File Path="tests/Common.targets" />
     <Project Path="tests/Buildvana.Core.Configuration.Tests/Buildvana.Core.Configuration.Tests.csproj" />
     <Project Path="tests/Buildvana.Core.JsonSchema.Tests/Buildvana.Core.JsonSchema.Tests.csproj" />
+    <Project Path="tests/Buildvana.Core.Versioning.Tests/Buildvana.Core.Versioning.Tests.csproj" />
     <Project Path="tests/Buildvana.Tool.Tests/Buildvana.Tool.Tests.csproj" />
   </Folder>
 </Solution>

--- a/schemas/buildvana.schema.json
+++ b/schemas/buildvana.schema.json
@@ -48,10 +48,6 @@
         "dogfood": {
           "description": "Whether self-references are updated (dogfooding) during a release.",
           "type": "boolean"
-        },
-        "prereleaseTag": {
-          "description": "Prerelease tag applied to prerelease versions. When omitted, prerelease versions are not allowed.",
-          "type": "string"
         }
       },
       "additionalProperties": false
@@ -60,6 +56,10 @@
       "description": "Configuration for version computation.",
       "type": "object",
       "properties": {
+        "prereleaseTag": {
+          "description": "Prerelease tag applied to prerelease versions. When omitted, prerelease versions are not allowed.",
+          "type": "string"
+        },
         "assemblyVersionPrecision": {
           "description": "How many version components are carried into the assembly version.",
           "enum": [

--- a/schemas/buildvana.schema.json
+++ b/schemas/buildvana.schema.json
@@ -12,14 +12,14 @@
       "type": "object",
       "properties": {
         "branches": {
-          "description": "Regular expressions (matched against the short branch name) identifying branches that produce public releases.",
+          "description": "Regular expressions (implicitly anchored, matched against the whole short branch name) identifying branches that produce public releases.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "generateDocsFrom": {
-          "description": "Regular expressions (matched against the short branch name) identifying branches that documentation is generated from.",
+          "description": "Regular expressions (implicitly anchored, matched against the whole short branch name) identifying branches that documentation is generated from.",
           "type": "array",
           "items": {
             "type": "string"

--- a/schemas/buildvana.schema.json
+++ b/schemas/buildvana.schema.json
@@ -65,8 +65,7 @@
           "enum": [
             "major",
             "minor",
-            "build",
-            "revision"
+            "build"
           ]
         }
       },

--- a/src/Buildvana.Core.Abstractions/Versioning/VersionSpec.cs
+++ b/src/Buildvana.Core.Abstractions/Versioning/VersionSpec.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Represents a <c>MAJOR.MINOR[-]</c> version specification, as stored in a repository's version file.
+/// </summary>
+/// <param name="Major">The major version.</param>
+/// <param name="Minor">The minor version.</param>
+/// <param name="Prerelease">A value indicating whether the version line is a prerelease line.</param>
+public sealed record VersionSpec(int Major, int Minor, bool Prerelease)
+{
+    /// <summary>
+    /// Returns the canonical string representation of this version specification: <c>MAJOR.MINOR</c>,
+    /// followed by <c>-</c> if <see cref="Prerelease"/> is <see langword="true"/>.
+    /// </summary>
+    /// <returns>The canonical string representation of this version specification.</returns>
+    /// <remarks>
+    /// <para>A prerelease tag is never emitted: tag text in a version file is informational and is not part of
+    /// the specification. The result round-trips through parsing.</para>
+    /// </remarks>
+    public override string ToString() => FormattableString.Invariant($"{Major}.{Minor}{(Prerelease ? "-" : string.Empty)}");
+}

--- a/src/Buildvana.Core.Abstractions/Versioning/VersionSpecChange.cs
+++ b/src/Buildvana.Core.Abstractions/Versioning/VersionSpecChange.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Specifies how to modify the version specification upon publishing a release.
+/// </summary>
+public enum VersionSpecChange
+{
+    /// <summary>
+    /// Do not force a version increment; do not modify the prerelease marker.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Do not force a version increment; mark the version line as prerelease if it is not already.
+    /// </summary>
+    Unstable,
+
+    /// <summary>
+    /// Do not force a version increment; remove the prerelease marker if present.
+    /// </summary>
+    Stable,
+
+    /// <summary>
+    /// Force a minor version increment with respect to the latest stable version; mark the version line as prerelease.
+    /// </summary>
+    Minor,
+
+    /// <summary>
+    /// Force a major version increment and minor version reset with respect to the latest stable version;
+    /// mark the version line as prerelease.
+    /// </summary>
+    Major,
+}

--- a/src/Buildvana.Core.Configuration/AssemblyVersionPrecision.cs
+++ b/src/Buildvana.Core.Configuration/AssemblyVersionPrecision.cs
@@ -16,7 +16,4 @@ public enum AssemblyVersionPrecision
 
     /// <summary>The major, minor, and build components are significant (<c>major.minor.build.0</c>).</summary>
     Build,
-
-    /// <summary>All four components are significant (<c>major.minor.build.revision</c>).</summary>
-    Revision,
 }

--- a/src/Buildvana.Core.Configuration/ReleaseConfig.cs
+++ b/src/Buildvana.Core.Configuration/ReleaseConfig.cs
@@ -40,8 +40,4 @@ public sealed record ReleaseConfig
     /// <summary>Gets a value indicating whether self-references are updated (dogfooding) during a release.</summary>
     [Description("Whether self-references are updated (dogfooding) during a release.")]
     public bool? Dogfood { get; init; }
-
-    /// <summary>Gets the prerelease tag applied to prerelease versions.</summary>
-    [Description("Prerelease tag applied to prerelease versions. When omitted, prerelease versions are not allowed.")]
-    public string? PrereleaseTag { get; init; }
 }

--- a/src/Buildvana.Core.Configuration/ReleaseConfig.cs
+++ b/src/Buildvana.Core.Configuration/ReleaseConfig.cs
@@ -14,11 +14,11 @@ namespace Buildvana.Core.Configuration;
 public sealed record ReleaseConfig
 {
     /// <summary>Gets the regular expressions identifying branches that produce public releases.</summary>
-    [Description("Regular expressions (matched against the short branch name) identifying branches that produce public releases.")]
+    [Description("Regular expressions (implicitly anchored, matched against the whole short branch name) identifying branches that produce public releases.")]
     public IReadOnlyList<string>? Branches { get; init; }
 
     /// <summary>Gets the regular expressions identifying branches that documentation is generated from.</summary>
-    [Description("Regular expressions (matched against the short branch name) identifying branches that documentation is generated from.")]
+    [Description("Regular expressions (implicitly anchored, matched against the whole short branch name) identifying branches that documentation is generated from.")]
     public IReadOnlyList<string>? GenerateDocsFrom { get; init; }
 
     /// <summary>Gets the build configuration used to produce release artifacts.</summary>

--- a/src/Buildvana.Core.Configuration/VersioningConfig.cs
+++ b/src/Buildvana.Core.Configuration/VersioningConfig.cs
@@ -12,6 +12,10 @@ namespace Buildvana.Core.Configuration;
 [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 public sealed record VersioningConfig
 {
+    /// <summary>Gets the prerelease tag applied to prerelease versions.</summary>
+    [Description("Prerelease tag applied to prerelease versions. When omitted, prerelease versions are not allowed.")]
+    public string? PrereleaseTag { get; init; }
+
     /// <summary>Gets the assembly-version precision.</summary>
     [Description("How many version components are carried into the assembly version.")]
     public AssemblyVersionPrecision? AssemblyVersionPrecision { get; init; }

--- a/src/Buildvana.Core.Versioning/Buildvana.Core.Versioning.csproj
+++ b/src/Buildvana.Core.Versioning/Buildvana.Core.Versioning.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Buildvana versioning</Title>
+    <Description>Native version computation: VERSION file parsing, Git height, and the version string forms needed by builds and releases. Reports failures via BuildFailedException.</Description>
+    <TargetFramework>$(StandardTfm)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Buildvana.Core.Abstractions\Buildvana.Core.Abstractions.csproj" />
+    <ProjectReference Include="..\Buildvana.Core.Configuration\Buildvana.Core.Configuration.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Diagnostics" />
+    <PackageReference Include="LibGit2Sharp" />
+    <PackageReference Include="NuGet.Versioning" />
+  </ItemGroup>
+
+</Project>

--- a/src/Buildvana.Core.Versioning/GitHeightCalculator.cs
+++ b/src/Buildvana.Core.Versioning/GitHeightCalculator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Buildvana.Core;
 using CommunityToolkit.Diagnostics;
 using LibGit2Sharp;
 

--- a/src/Buildvana.Core.Versioning/GitHeightCalculator.cs
+++ b/src/Buildvana.Core.Versioning/GitHeightCalculator.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using Buildvana.Core;
+using CommunityToolkit.Diagnostics;
+using LibGit2Sharp;
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Computes the Git height of a version line: the number of commits in the longest parent-path from
+/// <c>HEAD</c> (inclusive) across consecutive commits whose committed version file parses to the same
+/// <c>MAJOR.MINOR</c> as the version being built. The walk stops where the version file is absent,
+/// malformed, or differs in <c>MAJOR.MINOR</c>; prerelease-only differences do not stop it.
+/// </summary>
+/// <remarks>
+/// <para>The height rules mirror Nerdbank.GitVersioning (© .NET Foundation and Contributors, MIT license;
+/// see <c>LibGit2GitExtensions.GetHeight</c> and <c>SemanticVersion.WillVersionChangeResetVersionHeight</c>
+/// at https://github.com/dotnet/Nerdbank.GitVersioning): each qualifying commit contributes 1 plus the
+/// maximum height among its parents, so the commit that bumps <c>MAJOR.MINOR</c> has height 1, and 0 is
+/// reserved for version lines with no committed history. Unlike NBGV, a commit qualifies based on the
+/// version file's <c>MAJOR.MINOR</c> alone: there are no path filters, and the version file is plain text
+/// rather than JSON.</para>
+/// <para>Heights are computed from the available commit graph; shallow clones therefore yield short heights.</para>
+/// <para>This class is the library's only Git touchpoint; its public surface deliberately exposes no
+/// LibGit2Sharp types.</para>
+/// </remarks>
+public sealed class GitHeightCalculator
+{
+    private readonly string _versionFileName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitHeightCalculator"/> class.
+    /// </summary>
+    /// <param name="versionFileName">The name of the version file, relative to the repository root.</param>
+    public GitHeightCalculator(string versionFileName)
+    {
+        Guard.IsNotNullOrEmpty(versionFileName);
+        _versionFileName = versionFileName;
+    }
+
+    /// <summary>
+    /// Calculates the Git height of the version line identified by <paramref name="expected"/> in the
+    /// repository at <paramref name="repositoryDirectory"/>, along with the repository facts needed to
+    /// compute version strings.
+    /// </summary>
+    /// <param name="repositoryDirectory">The directory of the Git repository.</param>
+    /// <param name="expected">The version specification being built; only <see cref="VersionSpec.Major"/>
+    /// and <see cref="VersionSpec.Minor"/> take part in the computation.</param>
+    /// <returns>A newly-created <see cref="GitHeightResult"/>.</returns>
+    /// <exception cref="BuildFailedException">There is no Git repository at <paramref name="repositoryDirectory"/>.</exception>
+    public GitHeightResult Calculate(string repositoryDirectory, VersionSpec expected)
+    {
+        Guard.IsNotNullOrEmpty(repositoryDirectory);
+        Guard.IsNotNull(expected);
+        BuildFailedException.ThrowIfNot(Repository.IsValid(repositoryDirectory), $"There is no Git repository at {repositoryDirectory}");
+        using var repository = new Repository(repositoryDirectory);
+        var head = repository.Head;
+        var tip = head.Tip;
+        if (tip is null)
+        {
+            return new GitHeightResult(0, string.Empty, null);
+        }
+
+        var isOnBranch = head.CanonicalName.StartsWith("refs/heads/", StringComparison.Ordinal);
+        var branchName = isOnBranch ? head.FriendlyName : string.Empty;
+        return new GitHeightResult(ComputeHeight(tip, expected), branchName, tip.Sha);
+    }
+
+    private int ComputeHeight(Commit tip, VersionSpec expected)
+    {
+        // Iterative post-order walk with memoization: a commit's height is computed only after all its
+        // parents'. Commits outside the version line get height 0 without visiting their parents, so the
+        // walk is bounded by the size of the line plus its immediate frontier.
+        var heights = new Dictionary<ObjectId, int>();
+        var lineBlobs = new Dictionary<ObjectId, bool>();
+        var stack = new Stack<Commit>();
+        stack.Push(tip);
+        while (stack.Count > 0)
+        {
+            var commit = stack.Peek();
+            if (heights.ContainsKey(commit.Id))
+            {
+                _ = stack.Pop();
+                continue;
+            }
+
+            if (!IsInLine(commit, expected, lineBlobs))
+            {
+                heights[commit.Id] = 0;
+                _ = stack.Pop();
+                continue;
+            }
+
+            var maxParentHeight = 0;
+            var hasPendingParents = false;
+            foreach (var parent in commit.Parents)
+            {
+                if (heights.TryGetValue(parent.Id, out var parentHeight))
+                {
+                    maxParentHeight = Math.Max(maxParentHeight, parentHeight);
+                }
+                else
+                {
+                    stack.Push(parent);
+                    hasPendingParents = true;
+                }
+            }
+
+            if (!hasPendingParents)
+            {
+                heights[commit.Id] = 1 + maxParentHeight;
+                _ = stack.Pop();
+            }
+        }
+
+        return heights[tip.Id];
+    }
+
+    private bool IsInLine(Commit commit, VersionSpec expected, Dictionary<ObjectId, bool> lineBlobs)
+    {
+        var entry = commit[_versionFileName];
+        if (entry is not { TargetType: TreeEntryTargetType.Blob })
+        {
+            return false;
+        }
+
+        var blobId = entry.Target.Id;
+        if (lineBlobs.TryGetValue(blobId, out var isInLine))
+        {
+            return isInLine;
+        }
+
+        var content = ((Blob)entry.Target).GetContentText();
+        var hasBom = content.Length > 0 && content[0] == 0xFEFF;
+        if (hasBom)
+        {
+            // Tolerate a UTF-8 byte order mark in a committed version file: the parser's regex would reject it.
+            content = content[1..];
+        }
+
+        isInLine = VersionSpec.TryParse(content, out var spec)
+            && spec.Major == expected.Major
+            && spec.Minor == expected.Minor;
+        lineBlobs[blobId] = isInLine;
+        return isInLine;
+    }
+}

--- a/src/Buildvana.Core.Versioning/GitHeightResult.cs
+++ b/src/Buildvana.Core.Versioning/GitHeightResult.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Represents the result of a <see cref="GitHeightCalculator"/> run: the Git height of the version line
+/// being built, plus the repository facts needed to compute version strings.
+/// </summary>
+/// <param name="Height">The Git height of the version line being built. 0 means the line has no committed
+/// history: the version file is not committed, its committed <c>MAJOR.MINOR</c> differs from the one being
+/// built, or the repository has no commits.</param>
+/// <param name="BranchName">The short name of the current branch, or the empty string if HEAD is detached
+/// or the current branch has no commits.</param>
+/// <param name="CommitId">The SHA of the current HEAD commit, or <see langword="null"/> if the repository
+/// has no commits.</param>
+public sealed record GitHeightResult(int Height, string BranchName, string? CommitId);

--- a/src/Buildvana.Core.Versioning/VersionSpecExtensions-private.cs
+++ b/src/Buildvana.Core.Versioning/VersionSpecExtensions-private.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Text.RegularExpressions;
+
+namespace Buildvana.Core.Versioning;
+
+partial class VersionSpecExtensions
+{
+    private static readonly Regex VersionSpecRegex = GetVersionSpecRegex();
+
+    // Semver grammar minus patch and build metadata, with a single loosened (ASCII-alphanumeric) tag whose
+    // text is not captured: only the presence of the dash matters. The \s*$ tail tolerates trailing
+    // whitespace (e.g. the version file's trailing newline) but rejects trailing junk.
+    [GeneratedRegex(
+        @"^(?<Major>0|[1-9][0-9]*)\.(?<Minor>0|[1-9][0-9]*)((?<Prerelease>-)[0-9a-zA-Z]*)?\s*$",
+        RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant)]
+    private static partial Regex GetVersionSpecRegex();
+}

--- a/src/Buildvana.Core.Versioning/VersionSpecExtensions.cs
+++ b/src/Buildvana.Core.Versioning/VersionSpecExtensions.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Buildvana.Core;
+using CommunityToolkit.Diagnostics;
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Provides extension methods for <see cref="VersionSpec"/> instances.
+/// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible — false positive on C# 14 extension blocks; fixed in .NET 11, backport to .NET 10 requested in https://github.com/dotnet/sdk/issues/53984
+#pragma warning disable CA1708 // Identifiers should differ by more than case — false positive on classes with C# 14 extension blocks; fixed in .NET 11, https://github.com/dotnet/sdk/issues/51716
+public static partial class VersionSpecExtensions
+{
+    extension(VersionSpec)
+    {
+        /// <summary>
+        /// Parses a version specification in <c>MAJOR.MINOR[-[tag]]</c> format.
+        /// </summary>
+        /// <param name="str">The string to parse.</param>
+        /// <returns>A newly-created <see cref="VersionSpec"/>.</returns>
+        /// <exception cref="BuildFailedException"><paramref name="str"/> is not a valid version specification.</exception>
+        /// <remarks>
+        /// <para>The presence of <c>-</c> after the minor version marks a prerelease line; the tag after it is
+        /// optional, restricted to ASCII letters and digits, and informational (its text is not captured).
+        /// There is no <c>v</c> prefix. Trailing whitespace is tolerated; anything else after the
+        /// specification is not.</para>
+        /// </remarks>
+        public static VersionSpec Parse(string str)
+        {
+            Guard.IsNotNull(str);
+            BuildFailedException.ThrowIfNot(
+                VersionSpec.TryParse(str, out var result),
+                $"Invalid version specification '{str.Trim()}'.");
+            return result;
+        }
+
+        /// <summary>
+        /// Attempts to parse a version specification in <c>MAJOR.MINOR[-[tag]]</c> format.
+        /// </summary>
+        /// <param name="str">The string to parse.</param>
+        /// <param name="result">When this method returns <see langword="true"/>, a newly-created
+        /// <see cref="VersionSpec"/>. This parameter is passed uninitialized.</param>
+        /// <returns><see langword="true"/> if successful, <see langword="false"/> otherwise.</returns>
+        /// <remarks>
+        /// <para>See <see cref="Parse"/> for the accepted format.</para>
+        /// </remarks>
+        public static bool TryParse([NotNullWhen(true)] string? str, [MaybeNullWhen(false)] out VersionSpec result)
+        {
+            result = null;
+            if (str is null)
+            {
+                return false;
+            }
+
+            var match = VersionSpecRegex.Match(str);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            // The regex only lets digit runs through, so a failed parse can only mean int overflow.
+            var hasMajor = int.TryParse(match.Groups["Major"].ValueSpan, NumberStyles.None, CultureInfo.InvariantCulture, out var major);
+            var hasMinor = int.TryParse(match.Groups["Minor"].ValueSpan, NumberStyles.None, CultureInfo.InvariantCulture, out var minor);
+            if (!hasMajor || !hasMinor)
+            {
+                return false;
+            }
+
+            result = new(major, minor, match.Groups["Prerelease"].Success);
+            return true;
+        }
+    }
+}

--- a/src/Buildvana.Core.Versioning/VersionSpecExtensions.cs
+++ b/src/Buildvana.Core.Versioning/VersionSpecExtensions.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using Buildvana.Core;
 using CommunityToolkit.Diagnostics;
 
 namespace Buildvana.Core.Versioning;

--- a/src/Buildvana.Core.Versioning/VersionSpecExtensions.cs
+++ b/src/Buildvana.Core.Versioning/VersionSpecExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using CommunityToolkit.Diagnostics;
@@ -21,6 +22,7 @@ public static partial class VersionSpecExtensions
         /// </summary>
         /// <param name="str">The string to parse.</param>
         /// <returns>A newly-created <see cref="VersionSpec"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="str"/> is <see langword="null"/>.</exception>
         /// <exception cref="BuildFailedException"><paramref name="str"/> is not a valid version specification.</exception>
         /// <remarks>
         /// <para>The presence of <c>-</c> after the minor version marks a prerelease line; the tag after it is

--- a/src/Buildvana.Core.Versioning/VersioningService.cs
+++ b/src/Buildvana.Core.Versioning/VersioningService.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Security;
 using Buildvana.Core.Configuration;
 using Buildvana.Core.ConsoleOutput;
 using Buildvana.Core.HomeDirectory;
@@ -125,7 +126,7 @@ public sealed class VersioningService
         {
             text = File.ReadAllText(path);
         }
-        catch (IOException e)
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or SecurityException)
         {
             throw new BuildFailedException($"Could not read from {path}: {e.Message}", e);
         }

--- a/src/Buildvana.Core.Versioning/VersioningService.cs
+++ b/src/Buildvana.Core.Versioning/VersioningService.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Buildvana.Core;
+using Buildvana.Core.Configuration;
+using Buildvana.Core.ConsoleOutput;
+using Buildvana.Core.HomeDirectory;
+using CommunityToolkit.Diagnostics;
+using NuGet.Versioning;
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Computes the version being built from the repository's version file, Git height, and versioning settings,
+/// and exposes it in the string forms needed by builds and releases.
+/// </summary>
+/// <remarks>
+/// <para>The version file (<see cref="VersionFileName"/>, in the home directory) holds a
+/// <c>MAJOR.MINOR[-[tag]]</c> specification; the patch number is the Git height of the version line
+/// (see <see cref="GitHeightCalculator"/>). All values are computed once, on construction.</para>
+/// </remarks>
+public sealed class VersioningService
+{
+    /// <summary>
+    /// The name of the version file, relative to the home directory.
+    /// </summary>
+    public const string VersionFileName = "VERSION";
+
+    private const int ShortCommitIdLength = 10;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VersioningService"/> class, computing the version being built.
+    /// </summary>
+    /// <param name="reporter">The reporter used to log the computed version.</param>
+    /// <param name="home">The home directory provider used to locate the version file and the Git repository.</param>
+    /// <param name="settings">The versioning settings.</param>
+    /// <param name="heightCalculator">The calculator providing the Git height of the version line.</param>
+    /// <exception cref="BuildFailedException">
+    /// <para>The version file is absent or does not contain a valid version specification.</para>
+    /// <para>The version is a prerelease, but <see cref="VersioningSettings.PrereleaseTag"/> is unset or invalid.</para>
+    /// <para>There is no Git repository in the home directory, or a <c>release.branches</c> pattern is invalid.</para>
+    /// </exception>
+    public VersioningService(
+        IReporter reporter,
+        IHomeDirectoryProvider home,
+        VersioningSettings settings,
+        GitHeightCalculator heightCalculator)
+    {
+        Guard.IsNotNull(reporter);
+        Guard.IsNotNull(home);
+        Guard.IsNotNull(settings);
+        Guard.IsNotNull(heightCalculator);
+
+        var homeDirectory = home.HomeDirectory;
+        Spec = ReadVersionFile(Path.Combine(homeDirectory, VersionFileName));
+        var prereleaseTag = Spec.Prerelease ? GetPrereleaseTag(settings) : null;
+        var facts = heightCalculator.Calculate(homeDirectory, Spec);
+        Height = facts.Height;
+        CommitId = facts.CommitId;
+        IsPublicRelease = settings.IsPublicReleaseBranch(facts.BranchName);
+        SimpleVersion = FormattableString.Invariant($"{Spec.Major}.{Spec.Minor}.{Height}");
+        SemVer = prereleaseTag is null ? SimpleVersion : $"{SimpleVersion}-{prereleaseTag}";
+        AssemblyVersion = ComputeAssemblyVersion(Spec, Height, settings.AssemblyVersionPrecision);
+        InformationalVersion = ComputeInformationalVersion(SemVer, Spec.Prerelease, IsPublicRelease, CommitId);
+        var publicity = IsPublicRelease ? "public release" : "not a public release";
+        reporter.Info(FormattableString.Invariant($"Version {SemVer} (height {Height}, {publicity})"));
+    }
+
+    /// <summary>
+    /// Gets the version specification read from the version file.
+    /// </summary>
+    public VersionSpec Spec { get; }
+
+    /// <summary>
+    /// Gets the Git height of the version line being built, used as the patch number.
+    /// </summary>
+    public int Height { get; }
+
+    /// <summary>
+    /// Gets the SHA of the current HEAD commit, or <see langword="null"/> if the repository has no commits.
+    /// </summary>
+    public string? CommitId { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether a public release can be built, i.e. whether the current branch matches
+    /// one of the configured <c>release.branches</c> patterns.
+    /// </summary>
+    public bool IsPublicRelease { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the version being built is a prerelease.
+    /// </summary>
+    public bool IsPrerelease => Spec.Prerelease;
+
+    /// <summary>
+    /// Gets the version in simple <c>MAJOR.MINOR.PATCH</c> form, without any prerelease tag.
+    /// </summary>
+    public string SimpleVersion { get; }
+
+    /// <summary>
+    /// Gets the full semantic version: <see cref="SimpleVersion"/>, plus <c>-tag</c> when the version is a
+    /// prerelease. Carries no Git metadata.
+    /// </summary>
+    public string SemVer { get; }
+
+    /// <summary>
+    /// Gets the assembly version: <see cref="VersionSpec.Major"/>, <see cref="VersionSpec.Minor"/>, and
+    /// <see cref="Height"/> zeroed out below the configured precision, plus a fourth component that is
+    /// always 0.
+    /// </summary>
+    public string AssemblyVersion { get; }
+
+    /// <summary>
+    /// Gets the informational version: <see cref="SemVer"/>, plus a <c>g</c>-prefixed short commit ID
+    /// appended to the prerelease part when the build is not a public release.
+    /// </summary>
+    public string InformationalVersion { get; }
+
+    private static VersionSpec ReadVersionFile(string path)
+    {
+        BuildFailedException.ThrowIfNot(File.Exists(path), $"Version file {path} not found.");
+        string text;
+        try
+        {
+            text = File.ReadAllText(path);
+        }
+        catch (IOException e)
+        {
+            throw new BuildFailedException($"Could not read from {path}: {e.Message}", e);
+        }
+
+        BuildFailedException.ThrowIfNot(
+            VersionSpec.TryParse(text, out var spec),
+            $"{path} contains an invalid version specification '{text.Trim()}'.");
+        return spec;
+    }
+
+    private static string GetPrereleaseTag(VersioningSettings settings)
+    {
+        var tag = settings.PrereleaseTag;
+        BuildFailedException.ThrowIf(
+            string.IsNullOrEmpty(tag),
+            $"{VersionFileName} specifies a prerelease version, but versioning.prereleaseTag is not set in the configuration file.");
+        var isValid = SemanticVersion.TryParse(FormattableString.Invariant($"0.0.0-{tag}"), out _);
+        BuildFailedException.ThrowIfNot(
+            isValid,
+            $"'{tag}' (versioning.prereleaseTag in the configuration file) is not a valid prerelease tag.");
+        return tag;
+    }
+
+    private static string ComputeAssemblyVersion(VersionSpec spec, int height, AssemblyVersionPrecision precision)
+    {
+        var minor = precision >= AssemblyVersionPrecision.Minor ? spec.Minor : 0;
+        var build = precision >= AssemblyVersionPrecision.Build ? height : 0;
+        return FormattableString.Invariant($"{spec.Major}.{minor}.{build}.0");
+    }
+
+    private static string ComputeInformationalVersion(string semVer, bool prerelease, bool isPublicRelease, string? commitId)
+    {
+        if (isPublicRelease || commitId is null)
+        {
+            return semVer;
+        }
+
+        var separator = prerelease ? '.' : '-';
+        return FormattableString.Invariant($"{semVer}{separator}g{commitId[..ShortCommitIdLength]}");
+    }
+}

--- a/src/Buildvana.Core.Versioning/VersioningService.cs
+++ b/src/Buildvana.Core.Versioning/VersioningService.cs
@@ -131,9 +131,10 @@ public sealed class VersioningService
             throw new BuildFailedException($"Could not read from {path}: {e.Message}", e);
         }
 
+        text = text.Trim();
         BuildFailedException.ThrowIfNot(
             VersionSpec.TryParse(text, out var spec),
-            $"{path} contains an invalid version specification '{text.Trim()}'.");
+            $"{path} contains an invalid version specification '{text}'.");
         return spec;
     }
 

--- a/src/Buildvana.Core.Versioning/VersioningService.cs
+++ b/src/Buildvana.Core.Versioning/VersioningService.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using Buildvana.Core;
 using Buildvana.Core.Configuration;
 using Buildvana.Core.ConsoleOutput;
 using Buildvana.Core.HomeDirectory;

--- a/src/Buildvana.Core.Versioning/VersioningSettings.cs
+++ b/src/Buildvana.Core.Versioning/VersioningSettings.cs
@@ -55,6 +55,10 @@ public sealed class VersioningSettings
     /// <param name="branch">The short name of the current branch, or the empty string if HEAD is not on a branch.</param>
     /// <returns><see langword="true"/> if <paramref name="branch"/> matches at least one pattern;
     /// otherwise, <see langword="false"/>. The empty string never matches.</returns>
+    /// <remarks>
+    /// Patterns are implicitly anchored (wrapped in <c>^(?:</c>&#8230;<c>)$</c>): a pattern must match the whole
+    /// branch name, so <c>main</c> matches neither <c>domain</c> nor <c>main2</c>.
+    /// </remarks>
     /// <exception cref="BuildFailedException">A configured pattern is not a valid regular expression, or matching timed out.</exception>
     public bool IsPublicReleaseBranch(string branch)
     {
@@ -79,7 +83,11 @@ public sealed class VersioningSettings
     {
         try
         {
-            return Regex.IsMatch(branch, pattern, RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexMatchTimeout);
+            return Regex.IsMatch(
+                branch,
+                $"^(?:{pattern})$",
+                RegexOptions.Compiled | RegexOptions.CultureInvariant,
+                RegexMatchTimeout);
         }
         catch (ArgumentException ex)
         {

--- a/src/Buildvana.Core.Versioning/VersioningSettings.cs
+++ b/src/Buildvana.Core.Versioning/VersioningSettings.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using Buildvana.Core;
 using Buildvana.Core.Configuration;
 using CommunityToolkit.Diagnostics;
 

--- a/src/Buildvana.Core.Versioning/VersioningSettings.cs
+++ b/src/Buildvana.Core.Versioning/VersioningSettings.cs
@@ -44,7 +44,7 @@ public sealed class VersioningSettings
 
     /// <summary>
     /// Gets the assembly-version precision (<c>versioning.assemblyVersionPrecision</c>, or
-    /// <see cref="Configuration.AssemblyVersionPrecision.Major"/> when unset).
+    /// <see cref="AssemblyVersionPrecision.Major"/> when unset).
     /// </summary>
     public AssemblyVersionPrecision AssemblyVersionPrecision { get; }
 

--- a/src/Buildvana.Core.Versioning/VersioningSettings.cs
+++ b/src/Buildvana.Core.Versioning/VersioningSettings.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Buildvana.Core;
+using Buildvana.Core.Configuration;
+using CommunityToolkit.Diagnostics;
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Resolves versioning settings from a <see cref="BuildvanaConfig"/>: the public-release branch patterns
+/// (from the <c>release</c> section), plus the prerelease tag and the assembly-version precision (from the
+/// <c>versioning</c> section).
+/// </summary>
+public sealed class VersioningSettings
+{
+    private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VersioningSettings"/> class.
+    /// </summary>
+    /// <param name="config">The Buildvana configuration to read the <c>release</c> and <c>versioning</c> sections from.</param>
+    public VersioningSettings(BuildvanaConfig config)
+    {
+        Guard.IsNotNull(config);
+        PublicReleaseBranchPatterns = config.Release?.Branches ?? [];
+        PrereleaseTag = config.Versioning?.PrereleaseTag;
+        AssemblyVersionPrecision = config.Versioning?.AssemblyVersionPrecision ?? AssemblyVersionPrecision.Major;
+    }
+
+    /// <summary>
+    /// Gets the regular expressions identifying branches that produce public releases (<c>release.branches</c>).
+    /// When empty, no branch produces public releases.
+    /// </summary>
+    public IReadOnlyList<string> PublicReleaseBranchPatterns { get; }
+
+    /// <summary>
+    /// Gets the prerelease tag applied to prerelease versions (<c>versioning.prereleaseTag</c>), or
+    /// <see langword="null"/> when unset, in which case prerelease versions are not allowed.
+    /// </summary>
+    public string? PrereleaseTag { get; }
+
+    /// <summary>
+    /// Gets the assembly-version precision (<c>versioning.assemblyVersionPrecision</c>, or
+    /// <see cref="Configuration.AssemblyVersionPrecision.Major"/> when unset).
+    /// </summary>
+    public AssemblyVersionPrecision AssemblyVersionPrecision { get; }
+
+    /// <summary>
+    /// Determines whether releasing from <paramref name="branch"/> produces a public release, by matching it
+    /// against the configured <c>release.branches</c> regular expressions.
+    /// </summary>
+    /// <param name="branch">The short name of the current branch, or the empty string if HEAD is not on a branch.</param>
+    /// <returns><see langword="true"/> if <paramref name="branch"/> matches at least one pattern;
+    /// otherwise, <see langword="false"/>. The empty string never matches.</returns>
+    /// <exception cref="BuildFailedException">A configured pattern is not a valid regular expression, or matching timed out.</exception>
+    public bool IsPublicReleaseBranch(string branch)
+    {
+        Guard.IsNotNull(branch);
+        if (branch.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var pattern in PublicReleaseBranchPatterns)
+        {
+            if (IsMatch(pattern, branch))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsMatch(string pattern, string branch)
+    {
+        try
+        {
+            return Regex.IsMatch(branch, pattern, RegexOptions.Compiled | RegexOptions.CultureInvariant, RegexMatchTimeout);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new BuildFailedException($"Invalid regular expression '{pattern}' in release.branches: {ex.Message}");
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            throw new BuildFailedException($"Regular expression '{pattern}' in release.branches timed out matching branch '{branch}'.");
+        }
+    }
+}

--- a/src/Buildvana.Tool/Subcommands/ReleaseSettings.cs
+++ b/src/Buildvana.Tool/Subcommands/ReleaseSettings.cs
@@ -22,7 +22,7 @@ namespace Buildvana.Tool.Subcommands;
 /// </summary>
 internal sealed class ReleaseSettings
 {
-    private static readonly IReadOnlyList<string> DefaultGenerateDocsFrom = ["^main$", "^master$"];
+    private static readonly IReadOnlyList<string> DefaultGenerateDocsFrom = ["main", "master"];
     private static readonly TimeSpan RegexMatchTimeout = TimeSpan.FromSeconds(1);
 
     private readonly ReleaseConfig? _config;
@@ -147,11 +147,15 @@ internal sealed class ReleaseSettings
 
     /// <summary>
     /// Determines whether documentation is generated when releasing from <paramref name="branch"/>, by matching it
-    /// against the configured <c>release.generateDocsFrom</c> regular expressions (default <c>^main$</c>/<c>^master$</c>).
+    /// against the configured <c>release.generateDocsFrom</c> regular expressions (default <c>main</c>/<c>master</c>).
     /// </summary>
     /// <param name="branch">The short name of the branch the release is created from.</param>
     /// <returns><see langword="true"/> if <paramref name="branch"/> matches at least one pattern; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="BuildFailedException">A configured pattern is not a valid regular expression, or matching timed out.</exception>
+    /// <remarks>
+    /// Patterns are implicitly anchored (wrapped in <c>^(?:</c>&#8230;<c>)$</c>): a pattern must match the whole
+    /// branch name, so <c>main</c> matches neither <c>domain</c> nor <c>main2</c>.
+    /// </remarks>
     public bool MatchesDocsBranch(string branch)
     {
         Guard.IsNotNull(branch);
@@ -176,7 +180,7 @@ internal sealed class ReleaseSettings
     {
         try
         {
-            return Regex.IsMatch(branch, pattern, RegexOptions.CultureInvariant, RegexMatchTimeout);
+            return Regex.IsMatch(branch, $"^(?:{pattern})$", RegexOptions.CultureInvariant, RegexMatchTimeout);
         }
         catch (ArgumentException ex)
         {

--- a/tests/Buildvana.Core.Versioning.Tests/Buildvana.Core.Versioning.Tests.csproj
+++ b/tests/Buildvana.Core.Versioning.Tests/Buildvana.Core.Versioning.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(StandardTfm)</TargetFramework>
+    <ClsCompliant>false</ClsCompliant>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LibGit2Sharp" />
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Buildvana.Core.Versioning\Buildvana.Core.Versioning.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Buildvana.Core.Versioning.Tests/FixedHomeDirectoryProvider.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/FixedHomeDirectoryProvider.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core.HomeDirectory;
+
+internal sealed class FixedHomeDirectoryProvider(string homeDirectory) : IHomeDirectoryProvider
+{
+    public string HomeDirectory => homeDirectory;
+}

--- a/tests/Buildvana.Core.Versioning.Tests/GitHeightCalculatorTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/GitHeightCalculatorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Text;
 using Buildvana.Core;
 using Buildvana.Core.Versioning;
 
@@ -144,9 +145,7 @@ internal sealed class GitHeightCalculatorTests
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "1.0\n");
         repo.CommitAll();
-
-        // File.WriteAllText encodes the leading U+FEFF as the UTF-8 BOM bytes on disk.
-        repo.WriteFile("VERSION", "\uFEFF1.0\n");
+        repo.WriteFile("VERSION", "1.0\n", new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
         repo.CommitAll();
         await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(2);
     }

--- a/tests/Buildvana.Core.Versioning.Tests/GitHeightCalculatorTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/GitHeightCalculatorTests.cs
@@ -139,6 +139,19 @@ internal sealed class GitHeightCalculatorTests
     }
 
     [Test]
+    public async Task Calculate_CommittedVersionFileWithBom_DoesNotStopWalk()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+
+        // File.WriteAllText encodes the leading U+FEFF as the UTF-8 BOM bytes on disk.
+        repo.WriteFile("VERSION", "\uFEFF1.0\n");
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Calculate_OnBranch_ReportsBranchNameAndCommit()
     {
         using var repo = new TempGitRepo();

--- a/tests/Buildvana.Core.Versioning.Tests/GitHeightCalculatorTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/GitHeightCalculatorTests.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core;
+using Buildvana.Core.Versioning;
+
+internal sealed class GitHeightCalculatorTests
+{
+    [Test]
+    public async Task Calculate_WithoutRepository_ThrowsBuildFailedException()
+    {
+        var directory = Directory.CreateTempSubdirectory("bv-test-");
+        try
+        {
+            var calculator = new GitHeightCalculator("VERSION");
+            BuildFailedException? exception = null;
+            try
+            {
+                _ = calculator.Calculate(directory.FullName, new VersionSpec(1, 0, false));
+            }
+            catch (BuildFailedException e)
+            {
+                exception = e;
+            }
+
+            await Assert.That(exception).IsNotNull();
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Calculate_UnbornHead_ReturnsZeroHeightAndNoCommit()
+    {
+        using var repo = new TempGitRepo();
+        var result = Calculate(repo, 1, 0);
+        await Assert.That(result).IsEqualTo(new GitHeightResult(0, string.Empty, null));
+    }
+
+    [Test]
+    public async Task Calculate_CommitIntroducingVersionFile_HasHeightOne()
+    {
+        using var repo = new TempGitRepo();
+        repo.CommitAll();
+        repo.CommitAll();
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Calculate_CommitsOnLine_IncrementHeight()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(2);
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Calculate_MajorMinorBump_ResetsHeight()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+        repo.CommitAll();
+        repo.WriteFile("VERSION", "1.1\n");
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 1).Height).IsEqualTo(1);
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 1).Height).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Calculate_PrereleaseOnlyChanges_DoNotResetHeight()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0-alpha\n");
+        repo.CommitAll();
+        repo.CommitAll();
+        repo.WriteFile("VERSION", "1.0-beta\n");
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(3);
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task Calculate_VersionFileNotCommitted_ReturnsZeroHeight()
+    {
+        using var repo = new TempGitRepo();
+        repo.CommitAll();
+        repo.WriteFile("VERSION", "1.0\n");
+        await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Calculate_UncommittedMajorMinorBump_ReturnsZeroHeight()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 1).Height).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Calculate_MergeCommit_UsesLongestPath()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+        var mainline = repo.CurrentBranchName;
+        repo.CheckoutNewBranch("side");
+        repo.CommitAll();
+        repo.CommitAll();
+        repo.CommitAll();
+        repo.Checkout(mainline);
+        repo.CommitAll();
+        repo.Merge("side");
+        await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task Calculate_MalformedCommittedVersionFile_StopsWalk()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "banana\n");
+        repo.CommitAll();
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+        await Assert.That(Calculate(repo, 1, 0).Height).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Calculate_OnBranch_ReportsBranchNameAndCommit()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+        var result = Calculate(repo, 1, 0);
+        await Assert.That(result.BranchName).IsEqualTo(repo.CurrentBranchName);
+        await Assert.That(result.CommitId).IsEqualTo(repo.HeadSha);
+    }
+
+    [Test]
+    public async Task Calculate_DetachedHead_ReportsEmptyBranchName()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0\n");
+        repo.CommitAll();
+        repo.CheckoutDetached();
+        var result = Calculate(repo, 1, 0);
+        await Assert.That(result.BranchName).IsEqualTo(string.Empty);
+        await Assert.That(result.Height).IsEqualTo(1);
+    }
+
+    private static GitHeightResult Calculate(TempGitRepo repo, int major, int minor)
+        => new GitHeightCalculator("VERSION").Calculate(repo.RootPath, new VersionSpec(major, minor, false));
+}

--- a/tests/Buildvana.Core.Versioning.Tests/TempGitRepo.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/TempGitRepo.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using LibGit2Sharp;
+
+internal sealed class TempGitRepo : IDisposable
+{
+    private readonly Repository _repository;
+
+    public TempGitRepo()
+    {
+        RootPath = Directory.CreateTempSubdirectory("bv-test-repo-").FullName;
+        _ = Repository.Init(RootPath);
+        _repository = new Repository(RootPath);
+    }
+
+    public string RootPath { get; }
+
+    public string CurrentBranchName => _repository.Head.FriendlyName;
+
+    public string HeadSha => _repository.Head.Tip.Sha;
+
+    public void WriteFile(string name, string content) => File.WriteAllText(Path.Combine(RootPath, name), content);
+
+    public void CommitAll(string message = "Test commit")
+    {
+        Commands.Stage(_repository, "*");
+        var signature = new Signature("Test", "test@example.com", DateTimeOffset.Now);
+        _ = _repository.Commit(message, signature, signature, new CommitOptions { AllowEmptyCommit = true });
+    }
+
+    public void CheckoutNewBranch(string name)
+    {
+        var branch = _repository.CreateBranch(name);
+        _ = Commands.Checkout(_repository, branch);
+    }
+
+    public void Checkout(string name) => _ = Commands.Checkout(_repository, _repository.Branches[name]);
+
+    public void CheckoutDetached() => _ = Commands.Checkout(_repository, _repository.Head.Tip);
+
+    public void Merge(string branchName)
+    {
+        var signature = new Signature("Test", "test@example.com", DateTimeOffset.Now);
+        var options = new MergeOptions { FastForwardStrategy = FastForwardStrategy.NoFastForward };
+        _ = _repository.Merge(_repository.Branches[branchName], signature, options);
+    }
+
+    public void Dispose()
+    {
+        _repository.Dispose();
+        DeleteDirectory(RootPath);
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        // Git object files are read-only; clear attributes so the recursive delete succeeds on Windows.
+        foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+        {
+            File.SetAttributes(file, FileAttributes.Normal);
+        }
+
+        Directory.Delete(path, recursive: true);
+    }
+}

--- a/tests/Buildvana.Core.Versioning.Tests/TempGitRepo.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/TempGitRepo.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Text;
 using LibGit2Sharp;
 
 internal sealed class TempGitRepo : IDisposable
 {
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
     private readonly Repository _repository;
 
     public TempGitRepo()
@@ -20,7 +23,8 @@ internal sealed class TempGitRepo : IDisposable
 
     public string HeadSha => _repository.Head.Tip.Sha;
 
-    public void WriteFile(string name, string content) => File.WriteAllText(Path.Combine(RootPath, name), content);
+    public void WriteFile(string name, string content, Encoding? encoding = null)
+        => File.WriteAllText(Path.Combine(RootPath, name), content, encoding ?? Utf8NoBom);
 
     public void CommitAll(string message = "Test commit")
     {

--- a/tests/Buildvana.Core.Versioning.Tests/VersionSpecParseTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersionSpecParseTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core;
+using Buildvana.Core.Versioning;
+
+internal sealed class VersionSpecParseTests
+{
+    [Test]
+    [Arguments("1.0", 1, 0, false)]
+    [Arguments("0.0", 0, 0, false)]
+    [Arguments("10.20", 10, 20, false)]
+    [Arguments("1.0-preview", 1, 0, true)]
+    [Arguments("1.0-", 1, 0, true)]
+    [Arguments("3.14-rc2", 3, 14, true)]
+    [Arguments("1.0\n", 1, 0, false)]
+    [Arguments("2.3-preview\r\n", 2, 3, true)]
+    [Arguments("1.0 ", 1, 0, false)]
+    public async Task TryParse_ValidInput_Parses(string input, int major, int minor, bool prerelease)
+    {
+        var parsed = VersionSpec.TryParse(input, out var result);
+        await Assert.That(parsed).IsTrue();
+        await Assert.That(result).IsEqualTo(new VersionSpec(major, minor, prerelease));
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("1")]
+    [Arguments("1.")]
+    [Arguments("1.0.3")]
+    [Arguments("v1.0")]
+    [Arguments("01.2")]
+    [Arguments("1.02")]
+    [Arguments(" 1.0")]
+    [Arguments("1.0 garbage")]
+    [Arguments("1.0-pre.view")]
+    [Arguments("1.0-pre_view")]
+    [Arguments("-1.0")]
+    [Arguments("banana")]
+    [Arguments("99999999999999999999.0")]
+    public async Task TryParse_InvalidInput_ReturnsFalse(string? input)
+    {
+        var parsed = VersionSpec.TryParse(input, out _);
+        await Assert.That(parsed).IsFalse();
+    }
+
+    [Test]
+    public async Task Parse_ValidInput_Parses()
+    {
+        await Assert.That(VersionSpec.Parse("2.1-foo")).IsEqualTo(new VersionSpec(2, 1, true));
+    }
+
+    [Test]
+    public async Task Parse_InvalidInput_ThrowsBuildFailedException()
+    {
+        BuildFailedException? exception = null;
+        try
+        {
+            _ = VersionSpec.Parse("banana");
+        }
+        catch (BuildFailedException e)
+        {
+            exception = e;
+        }
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("banana");
+    }
+
+    [Test]
+    [Arguments("1.0")]
+    [Arguments("2.3-")]
+    public async Task ToString_RoundTripsThroughParse(string canonical)
+    {
+        var spec = VersionSpec.Parse(canonical);
+        await Assert.That(spec.ToString()).IsEqualTo(canonical);
+    }
+}

--- a/tests/Buildvana.Core.Versioning.Tests/VersionSpecTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersionSpecTests.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core.Versioning;
+
+internal sealed class VersionSpecTests
+{
+    [Test]
+    public async Task ToString_StableSpec_EmitsMajorDotMinor()
+    {
+        await Assert.That(new VersionSpec(1, 0, false).ToString()).IsEqualTo("1.0");
+    }
+
+    [Test]
+    public async Task ToString_PrereleaseSpec_EmitsTrailingDash()
+    {
+        await Assert.That(new VersionSpec(2, 3, true).ToString()).IsEqualTo("2.3-");
+    }
+
+    [Test]
+    public async Task Equality_ComparesByValue()
+    {
+        await Assert.That(new VersionSpec(1, 2, true)).IsEqualTo(new VersionSpec(1, 2, true));
+        await Assert.That(new VersionSpec(1, 2, true)).IsNotEqualTo(new VersionSpec(1, 2, false));
+    }
+}

--- a/tests/Buildvana.Core.Versioning.Tests/VersioningServiceTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersioningServiceTests.cs
@@ -118,7 +118,6 @@ internal sealed class VersioningServiceTests
     [Arguments(AssemblyVersionPrecision.Major, "2.0.0.0")]
     [Arguments(AssemblyVersionPrecision.Minor, "2.3.0.0")]
     [Arguments(AssemblyVersionPrecision.Build, "2.3.1.0")]
-    [Arguments(AssemblyVersionPrecision.Revision, "2.3.1.0")]
     public async Task Constructor_AssemblyVersionHonorsPrecision(AssemblyVersionPrecision precision, string expected)
     {
         using var repo = new TempGitRepo();

--- a/tests/Buildvana.Core.Versioning.Tests/VersioningServiceTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersioningServiceTests.cs
@@ -13,7 +13,7 @@ internal sealed class VersioningServiceTests
     {
         using var repo = new TempGitRepo();
         repo.CommitAll();
-        var exception = Catch(() => CreateService(repo, new BuildvanaConfig()));
+        var exception = CatchCreate(repo, new BuildvanaConfig());
         await Assert.That(exception).IsNotNull();
         await Assert.That(exception!.Message).Contains("VERSION");
     }
@@ -24,7 +24,7 @@ internal sealed class VersioningServiceTests
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "banana\n");
         repo.CommitAll();
-        var exception = Catch(() => CreateService(repo, new BuildvanaConfig()));
+        var exception = CatchCreate(repo, new BuildvanaConfig());
         await Assert.That(exception).IsNotNull();
         await Assert.That(exception!.Message).Contains("banana");
     }
@@ -35,7 +35,7 @@ internal sealed class VersioningServiceTests
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "1.0-\n");
         repo.CommitAll();
-        var exception = Catch(() => CreateService(repo, new BuildvanaConfig()));
+        var exception = CatchCreate(repo, new BuildvanaConfig());
         await Assert.That(exception).IsNotNull();
         await Assert.That(exception!.Message).Contains("versioning.prereleaseTag");
     }
@@ -47,7 +47,7 @@ internal sealed class VersioningServiceTests
         repo.WriteFile("VERSION", "1.0-\n");
         repo.CommitAll();
         var config = new BuildvanaConfig { Versioning = new VersioningConfig { PrereleaseTag = "not valid" } };
-        var exception = Catch(() => CreateService(repo, config));
+        var exception = CatchCreate(repo, config);
         await Assert.That(exception).IsNotNull();
         await Assert.That(exception!.Message).Contains("not valid");
     }
@@ -146,11 +146,11 @@ internal sealed class VersioningServiceTests
             new VersioningSettings(config),
             new GitHeightCalculator(VersioningService.VersionFileName));
 
-    private static BuildFailedException? Catch(Action action)
+    private static BuildFailedException? CatchCreate(TempGitRepo repo, BuildvanaConfig config)
     {
         try
         {
-            action();
+            _ = CreateService(repo, config);
             return null;
         }
         catch (BuildFailedException e)

--- a/tests/Buildvana.Core.Versioning.Tests/VersioningServiceTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersioningServiceTests.cs
@@ -1,0 +1,161 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core;
+using Buildvana.Core.Configuration;
+using Buildvana.Core.ConsoleOutput;
+using Buildvana.Core.Versioning;
+
+internal sealed class VersioningServiceTests
+{
+    [Test]
+    public async Task Constructor_MissingVersionFile_Throws()
+    {
+        using var repo = new TempGitRepo();
+        repo.CommitAll();
+        var exception = Catch(() => CreateService(repo, new BuildvanaConfig()));
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("VERSION");
+    }
+
+    [Test]
+    public async Task Constructor_MalformedVersionFile_Throws()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "banana\n");
+        repo.CommitAll();
+        var exception = Catch(() => CreateService(repo, new BuildvanaConfig()));
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("banana");
+    }
+
+    [Test]
+    public async Task Constructor_PrereleaseWithoutTag_Throws()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0-\n");
+        repo.CommitAll();
+        var exception = Catch(() => CreateService(repo, new BuildvanaConfig()));
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("versioning.prereleaseTag");
+    }
+
+    [Test]
+    public async Task Constructor_InvalidPrereleaseTag_Throws()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.0-\n");
+        repo.CommitAll();
+        var config = new BuildvanaConfig { Versioning = new VersioningConfig { PrereleaseTag = "not valid" } };
+        var exception = Catch(() => CreateService(repo, config));
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("not valid");
+    }
+
+    [Test]
+    public async Task Constructor_StablePublicRelease_ComputesVersionStrings()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "2.3\n");
+        repo.CommitAll();
+        repo.CheckoutNewBranch("rel");
+        repo.CommitAll();
+        var config = new BuildvanaConfig { Release = new ReleaseConfig { Branches = ["^rel$"] } };
+        var service = CreateService(repo, config);
+        await Assert.That(service.Spec).IsEqualTo(new VersionSpec(2, 3, false));
+        await Assert.That(service.Height).IsEqualTo(2);
+        await Assert.That(service.IsPublicRelease).IsTrue();
+        await Assert.That(service.IsPrerelease).IsFalse();
+        await Assert.That(service.SimpleVersion).IsEqualTo("2.3.2");
+        await Assert.That(service.SemVer).IsEqualTo("2.3.2");
+        await Assert.That(service.InformationalVersion).IsEqualTo("2.3.2");
+        await Assert.That(service.CommitId).IsEqualTo(repo.HeadSha);
+    }
+
+    [Test]
+    public async Task Constructor_PrereleasePublicRelease_AppendsTagOnly()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "2.3-x\n");
+        repo.CommitAll();
+        repo.CheckoutNewBranch("rel");
+        var config = new BuildvanaConfig
+        {
+            Release = new ReleaseConfig { Branches = ["^rel$"] },
+            Versioning = new VersioningConfig { PrereleaseTag = "preview" },
+        };
+        var service = CreateService(repo, config);
+        await Assert.That(service.IsPrerelease).IsTrue();
+        await Assert.That(service.SemVer).IsEqualTo("2.3.1-preview");
+        await Assert.That(service.InformationalVersion).IsEqualTo("2.3.1-preview");
+    }
+
+    [Test]
+    public async Task Constructor_PrereleaseNonPublic_AppendsCommitIdToInformationalVersion()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "2.3-x\n");
+        repo.CommitAll();
+        var config = new BuildvanaConfig { Versioning = new VersioningConfig { PrereleaseTag = "preview" } };
+        var service = CreateService(repo, config);
+        await Assert.That(service.IsPublicRelease).IsFalse();
+        await Assert.That(service.SemVer).IsEqualTo("2.3.1-preview");
+        await Assert.That(service.InformationalVersion).IsEqualTo($"2.3.1-preview.g{repo.HeadSha[..10]}");
+    }
+
+    [Test]
+    public async Task Constructor_StableNonPublic_AppendsCommitIdAsPrerelease()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "2.3\n");
+        repo.CommitAll();
+        var service = CreateService(repo, new BuildvanaConfig());
+        await Assert.That(service.SemVer).IsEqualTo("2.3.1");
+        await Assert.That(service.InformationalVersion).IsEqualTo($"2.3.1-g{repo.HeadSha[..10]}");
+    }
+
+    [Test]
+    [Arguments(AssemblyVersionPrecision.Major, "2.0.0.0")]
+    [Arguments(AssemblyVersionPrecision.Minor, "2.3.0.0")]
+    [Arguments(AssemblyVersionPrecision.Build, "2.3.1.0")]
+    [Arguments(AssemblyVersionPrecision.Revision, "2.3.1.0")]
+    public async Task Constructor_AssemblyVersionHonorsPrecision(AssemblyVersionPrecision precision, string expected)
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "2.3\n");
+        repo.CommitAll();
+        var config = new BuildvanaConfig { Versioning = new VersioningConfig { AssemblyVersionPrecision = precision } };
+        var service = CreateService(repo, config);
+        await Assert.That(service.AssemblyVersion).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Constructor_DefaultPrecision_IsMajor()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "2.3\n");
+        repo.CommitAll();
+        var service = CreateService(repo, new BuildvanaConfig());
+        await Assert.That(service.AssemblyVersion).IsEqualTo("2.0.0.0");
+    }
+
+    private static VersioningService CreateService(TempGitRepo repo, BuildvanaConfig config)
+        => new(
+            NullReporter.Instance,
+            new FixedHomeDirectoryProvider(repo.RootPath),
+            new VersioningSettings(config),
+            new GitHeightCalculator(VersioningService.VersionFileName));
+
+    private static BuildFailedException? Catch(Action action)
+    {
+        try
+        {
+            action();
+            return null;
+        }
+        catch (BuildFailedException e)
+        {
+            return e;
+        }
+    }
+}

--- a/tests/Buildvana.Core.Versioning.Tests/VersioningSettingsTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersioningSettingsTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core;
+using Buildvana.Core.Configuration;
+using Buildvana.Core.Versioning;
+
+internal sealed class VersioningSettingsTests
+{
+    [Test]
+    public async Task Constructor_EmptyConfig_AppliesDefaults()
+    {
+        var settings = new VersioningSettings(new BuildvanaConfig());
+        await Assert.That(settings.PublicReleaseBranchPatterns.Count).IsEqualTo(0);
+        await Assert.That(settings.PrereleaseTag).IsNull();
+        await Assert.That(settings.AssemblyVersionPrecision).IsEqualTo(AssemblyVersionPrecision.Major);
+    }
+
+    [Test]
+    public async Task Constructor_ReadsConfiguredValues()
+    {
+        var config = new BuildvanaConfig
+        {
+            Release = new ReleaseConfig { Branches = ["^main$"] },
+            Versioning = new VersioningConfig
+            {
+                PrereleaseTag = "preview",
+                AssemblyVersionPrecision = AssemblyVersionPrecision.Build,
+            },
+        };
+        var settings = new VersioningSettings(config);
+        await Assert.That(settings.PublicReleaseBranchPatterns.Count).IsEqualTo(1);
+        await Assert.That(settings.PrereleaseTag).IsEqualTo("preview");
+        await Assert.That(settings.AssemblyVersionPrecision).IsEqualTo(AssemblyVersionPrecision.Build);
+    }
+
+    [Test]
+    [Arguments("main", true)]
+    [Arguments("v2.0", true)]
+    [Arguments("feature/x", false)]
+    [Arguments("main2", false)]
+    [Arguments("", false)]
+    public async Task IsPublicReleaseBranch_MatchesConfiguredPatterns(string branch, bool expected)
+    {
+        var config = new BuildvanaConfig { Release = new ReleaseConfig { Branches = ["^main$", @"^v\d+\.\d+$"] } };
+        var settings = new VersioningSettings(config);
+        await Assert.That(settings.IsPublicReleaseBranch(branch)).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task IsPublicReleaseBranch_EmptyPatternList_NeverMatches()
+    {
+        var settings = new VersioningSettings(new BuildvanaConfig());
+        await Assert.That(settings.IsPublicReleaseBranch("main")).IsFalse();
+    }
+
+    [Test]
+    public async Task IsPublicReleaseBranch_InvalidPattern_ThrowsBuildFailedException()
+    {
+        var config = new BuildvanaConfig { Release = new ReleaseConfig { Branches = ["("] } };
+        var settings = new VersioningSettings(config);
+        BuildFailedException? exception = null;
+        try
+        {
+            _ = settings.IsPublicReleaseBranch("main");
+        }
+        catch (BuildFailedException e)
+        {
+            exception = e;
+        }
+
+        await Assert.That(exception).IsNotNull();
+        await Assert.That(exception!.Message).Contains("release.branches");
+    }
+}

--- a/tests/Buildvana.Core.Versioning.Tests/VersioningSettingsTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersioningSettingsTests.cs
@@ -48,6 +48,21 @@ internal sealed class VersioningSettingsTests
     }
 
     [Test]
+    [Arguments("main", true)]
+    [Arguments("master", true)]
+    [Arguments("domain", false)]
+    [Arguments("main2", false)]
+    [Arguments("release/2.0", true)]
+    [Arguments("prerelease/2.0", false)]
+    [Arguments("release/2.0.1", false)]
+    public async Task IsPublicReleaseBranch_ImplicitlyAnchorsPatterns(string branch, bool expected)
+    {
+        var config = new BuildvanaConfig { Release = new ReleaseConfig { Branches = ["main|master", @"release/\d+\.\d+"] } };
+        var settings = new VersioningSettings(config);
+        await Assert.That(settings.IsPublicReleaseBranch(branch)).IsEqualTo(expected);
+    }
+
+    [Test]
     public async Task IsPublicReleaseBranch_EmptyPatternList_NeverMatches()
     {
         var settings = new VersioningSettings(new BuildvanaConfig());

--- a/tests/Buildvana.Tool.Tests/ReleaseSettingsTests.cs
+++ b/tests/Buildvana.Tool.Tests/ReleaseSettingsTests.cs
@@ -98,6 +98,20 @@ internal sealed class ReleaseSettingsTests
     }
 
     [Test]
+    public async Task MatchesDocsBranch_ImplicitlyAnchorsPatterns()
+    {
+        var config = new BuildvanaConfig { Release = new() { GenerateDocsFrom = ["main|master", @"release/\d+\.\d+"] } };
+        var settings = Parse([], config);
+        await Assert.That(settings.MatchesDocsBranch("main")).IsTrue();
+        await Assert.That(settings.MatchesDocsBranch("master")).IsTrue();
+        await Assert.That(settings.MatchesDocsBranch("domain")).IsFalse();
+        await Assert.That(settings.MatchesDocsBranch("main2")).IsFalse();
+        await Assert.That(settings.MatchesDocsBranch("release/2.0")).IsTrue();
+        await Assert.That(settings.MatchesDocsBranch("prerelease/2.0")).IsFalse();
+        await Assert.That(settings.MatchesDocsBranch("release/2.0.1")).IsFalse();
+    }
+
+    [Test]
     public async Task MatchesDocsBranch_Throws_OnInvalidPattern()
     {
         var config = new BuildvanaConfig { Release = new() { GenerateDocsFrom = ["["] } };


### PR DESCRIPTION
﻿Phase 4 of #267. Closes #293.

## What's new

- **`Buildvana.Core.Abstractions`** gains the versioning definitions (namespace `Buildvana.Core.Versioning`): the `VersionSpec(Major, Minor, Prerelease)` record with canonical `ToString()`, and the `VersionSpecChange` enum.
- **New `Buildvana.Core.Versioning` library** (not packaged standalone; no live code wired to it yet):
  - `VersionSpec.Parse`/`TryParse` as C# 14 static extension members implementing the `MAJOR.MINOR[-[tag]]` grammar (tag text informational; trailing whitespace tolerated).
  - `GitHeightCalculator` — the single LibGit2Sharp git-height calculator, NBGV-parity rules verified against NBGV's source: a commit belongs to the version line when its committed `VERSION` parses to the same `MAJOR.MINOR`; each such commit contributes 1 + max(parent heights), so the bump commit has height 1 and merges take the longest path; prerelease-only changes never reset; 0 is reserved for lines with no committed history (uncommitted `VERSION` or bump, unborn HEAD). `LibGit2Sharp`/`NuGet.Versioning` appear in no public signature.
  - `VersioningSettings` — resolves `release.branches`, `versioning.prereleaseTag`, and `versioning.assemblyVersionPrecision` (default `major`); branch matching with anchored, compiled, culture-invariant regexes and a match timeout.
  - `VersioningService` — reads `VERSION` (fails loudly when absent or malformed, and when a prerelease line has no configured tag), computes the height, and exposes `SemVer` (never carries Git metadata), `SimpleVersion`, `AssemblyVersion` (precision-masked), `InformationalVersion` (short commit id appended on non-public builds, mirroring today's NpmPackageVersion behavior), plus `IsPublicRelease`, `IsPrerelease`, and `CommitId`.
- **Configuration**: `prereleaseTag` relocated from `release` to `versioning` (config is unreleased, so no migration concern); schema regenerated.
- **Branch patterns are implicitly anchored**: both `release.branches` matching (`VersioningSettings`) and `release.generateDocsFrom` matching (`bv`'s `ReleaseSettings`) wrap each configured pattern in `^(?:…)$`, so a pattern must match the whole short branch name — `main` no longer matches `domain` or `main2`. The `generateDocsFrom` defaults simplify to `main`/`master`, and the config descriptions (and regenerated schema) now document whole-name matching.
- **Configuration**: `AssemblyVersionPrecision.Revision` removed.
  The value was a no-op: versions are computed as `major.minor.height`, so there is no revision component and `ComputeAssemblyVersion` always emits `0` as the fourth part of the assembly version. Configuring `"revision"` produced output identical to `"build"`, so `Build` is now the maximum precision. Removed from the enum, the JSON schema, and the corresponding test case. Breaking for config files that used `"revision"`, which is acceptable on the 2.0 preview line.
- **Tests**: 72 TUnit cases — parse grammar (valid, malformed, overflow, round-trip), branch matching (including implicit anchoring), assembly-version precision, all height rules on temporary LibGit2Sharp repositories (merge longest-path, no-reset on prerelease flips, height 0 for uncommitted lines, detached/unborn HEAD), and the version string forms. `bv`'s docs-branch matching gains anchoring coverage too.

## Unchanged

`bv` behavior: the tool keeps its own versioning types and NBGV; nothing consumes the new library until Phase 7 (#296). The only `bv` change is the `generateDocsFrom` anchoring above. No changelog entry — internal-only, per the issue's acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
