### PR TITLE
Add IReporter-over-MSBuild adapter and BuildvanaSdkTask.Reporter

### DIFF
--- a/Buildvana.slnx
+++ b/Buildvana.slnx
@@ -55,6 +55,7 @@
     <Project Path="tests/Buildvana.Core.Configuration.Tests/Buildvana.Core.Configuration.Tests.csproj" />
     <Project Path="tests/Buildvana.Core.JsonSchema.Tests/Buildvana.Core.JsonSchema.Tests.csproj" />
     <Project Path="tests/Buildvana.Core.Versioning.Tests/Buildvana.Core.Versioning.Tests.csproj" />
+    <Project Path="tests/Buildvana.Sdk.Tasks.Tests/Buildvana.Sdk.Tasks.Tests.csproj" />
     <Project Path="tests/Buildvana.Tool.Tests/Buildvana.Tool.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/Buildvana.Core.Abstractions/ConsoleOutput/IReporter.cs
+++ b/src/Buildvana.Core.Abstractions/ConsoleOutput/IReporter.cs
@@ -37,7 +37,8 @@ public interface IReporter
     /// </summary>
     /// <param name="line">The line of child-process standard output to write.</param>
     /// <param name="minimumVerbosity">The line is written only when the reporter's <see cref="Verbosity"/> is at
-    /// least this value. If <see langword="null"/>, the line is always written.</param>
+    /// least this value. If <see langword="null"/>, the reporter applies no verbosity gate of its own; an
+    /// underlying output system may still apply its own filtering.</param>
     void ChildOutput(string line, Verbosity? minimumVerbosity);
 
     /// <summary>
@@ -46,6 +47,7 @@ public interface IReporter
     /// </summary>
     /// <param name="line">The line of child-process standard error to write.</param>
     /// <param name="minimumVerbosity">The line is written only when the reporter's <see cref="Verbosity"/> is at
-    /// least this value. If <see langword="null"/>, the line is always written.</param>
+    /// least this value. If <see langword="null"/>, the reporter applies no verbosity gate of its own; an
+    /// underlying output system may still apply its own filtering.</param>
     void ChildError(string line, Verbosity? minimumVerbosity);
 }

--- a/src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj
+++ b/src/Buildvana.Sdk.Tasks/Buildvana.Sdk.Tasks.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Buildvana.Sdk.Tasks.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Buildvana.Core.Abstractions\Buildvana.Core.Abstractions.csproj" />
     <ProjectReference Include="..\Buildvana.Core.Json\Buildvana.Core.Json.csproj" />
   </ItemGroup>

--- a/src/Buildvana.Sdk.Tasks/TaskLoggingHelperReporter.ActivityScope.cs
+++ b/src/Buildvana.Sdk.Tasks/TaskLoggingHelperReporter.ActivityScope.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using Buildvana.Core.ConsoleOutput;
+
+namespace Buildvana.Sdk;
+
+partial class TaskLoggingHelperReporter
+{
+    private sealed class ActivityScope : IActivityScope
+    {
+        private readonly TaskLoggingHelperReporter _reporter;
+        private readonly long _startTimestamp;
+        private bool _completed;
+        private bool _disposed;
+
+        public ActivityScope(TaskLoggingHelperReporter reporter, string title, int depth)
+        {
+            _reporter = reporter;
+            Title = title;
+            Depth = depth;
+            _startTimestamp = Stopwatch.GetTimestamp();
+        }
+
+        public string Title { get; }
+
+        public int Depth { get; }
+
+        public TimeSpan Elapsed => Stopwatch.GetElapsedTime(_startTimestamp);
+
+        public string? OutcomeMessage { get; private set; }
+
+        public void Complete(string? outcomeMessage = null)
+        {
+            _completed = true;
+            OutcomeMessage = outcomeMessage;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _reporter.EndActivity(this, _completed);
+        }
+    }
+}

--- a/src/Buildvana.Sdk.Tasks/TaskLoggingHelperReporter.cs
+++ b/src/Buildvana.Sdk.Tasks/TaskLoggingHelperReporter.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using Buildvana.Core.ConsoleOutput;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Buildvana.Sdk;
+
+/// <summary>
+/// An <see cref="IReporter"/> that forwards reported messages to MSBuild's
+/// <see cref="TaskLoggingHelper"/>, so that Core services hosted inside a task surface their
+/// human-facing output through the build's own loggers.
+/// </summary>
+/// <remarks>
+/// <para>Message levels map to MSBuild severities as follows: <see cref="MessageLevel.Error"/> and
+/// <see cref="MessageLevel.Warning"/> become build errors and warnings; <see cref="MessageLevel.Info"/>,
+/// <see cref="MessageLevel.Detail"/>, and <see cref="MessageLevel.Trace"/> become messages of
+/// <see cref="MessageImportance.High"/>, <see cref="MessageImportance.Normal"/>, and
+/// <see cref="MessageImportance.Low"/> importance respectively.</para>
+/// <para>Messages are always forwarded, regardless of <see cref="Verbosity"/>: visibility is governed by
+/// MSBuild's own verbosity and importance filtering, exactly like any other message logged by a task.
+/// <see cref="Verbosity"/> is derived from <see cref="IBuildEngine10.EngineServices"/> when available
+/// (falling back to fully permissive otherwise), so that callers checking it — such as the formatting
+/// helpers in <see cref="ReporterExtensions"/> — skip work whose output MSBuild would discard anyway.</para>
+/// <para>Activity start and outcome lines are logged at <see cref="MessageImportance.Normal"/> importance,
+/// so they are hidden at MSBuild's default (minimal) verbosity and visible from normal verbosity up.</para>
+/// <para>Child-process output and error lines are both forwarded as low-importance messages: MSBuild has no
+/// neutral standard-error channel, and logging a build error or warning would misrepresent — and, given how
+/// task success is determined, potentially fail the build over — stderr lines that many tools use for
+/// progress and hints.</para>
+/// </remarks>
+internal sealed partial class TaskLoggingHelperReporter : IReporter
+{
+    private readonly TaskLoggingHelper _log;
+    private readonly EngineServices? _engineServices;
+    private readonly Lock _activityLock = new();
+    private readonly Stack<ActivityScope> _activityStack = new();
+
+    public TaskLoggingHelperReporter(TaskLoggingHelper log, IBuildEngine engine)
+    {
+        ArgumentNullException.ThrowIfNull(log);
+        ArgumentNullException.ThrowIfNull(engine);
+        _log = log;
+        _engineServices = (engine as IBuildEngine10)?.EngineServices;
+    }
+
+    public Verbosity Verbosity => LogsMessagesOfImportance(MessageImportance.Low) ? Verbosity.Diagnostic
+        : LogsMessagesOfImportance(MessageImportance.Normal) ? Verbosity.Detailed
+        : LogsMessagesOfImportance(MessageImportance.High) ? Verbosity.Normal
+        : Verbosity.Minimal;
+
+    public void Report(MessageLevel level, string message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        switch (level)
+        {
+            case MessageLevel.Error:
+                _log.LogError("{0}", message);
+                break;
+            case MessageLevel.Warning:
+                _log.LogWarning("{0}", message);
+                break;
+            case MessageLevel.Info:
+                _log.LogMessage(MessageImportance.High, "{0}", message);
+                break;
+            case MessageLevel.Detail:
+                _log.LogMessage(MessageImportance.Normal, "{0}", message);
+                break;
+            case MessageLevel.Trace:
+                _log.LogMessage(MessageImportance.Low, "{0}", message);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(level), level, "Unknown message level.");
+        }
+    }
+
+    public IActivityScope BeginActivity(string title)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(title);
+        lock (_activityLock)
+        {
+            var depth = _activityStack.Count + 1;
+            var scope = new ActivityScope(this, title, depth);
+            _activityStack.Push(scope);
+            _log.LogMessage(
+                MessageImportance.Normal,
+                "{0}",
+                FormatActivityLine(depth, title, elapsed: null, outcomeMessage: null));
+            return scope;
+        }
+    }
+
+    public void ChildOutput(string line, Verbosity? minimumVerbosity)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+        if (minimumVerbosity is { } v && !this.IsVerbosityAtLeast(v))
+        {
+            return;
+        }
+
+        _log.LogMessage(MessageImportance.Low, "{0}", line);
+    }
+
+    public void ChildError(string line, Verbosity? minimumVerbosity)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+        if (minimumVerbosity is { } v && !this.IsVerbosityAtLeast(v))
+        {
+            return;
+        }
+
+        _log.LogMessage(MessageImportance.Low, "{0}", line);
+    }
+
+    // Same line format as ConsoleReporter, so activities look the same whether a service runs under `bv` or MSBuild.
+    private static string FormatActivityLine(int depth, string title, TimeSpan? elapsed, string? outcomeMessage)
+        => elapsed is { } e
+            ? string.Format(
+                CultureInfo.InvariantCulture,
+                "[{0}] {1}: done ({2:F1}s){3}{4}",
+                depth,
+                title,
+                e.TotalSeconds,
+                outcomeMessage is null ? string.Empty : " - ",
+                outcomeMessage)
+            : string.Format(CultureInfo.InvariantCulture, "[{0}] {1}: starting...", depth, title);
+
+    private bool LogsMessagesOfImportance(MessageImportance importance)
+        => _engineServices?.LogsMessagesOfImportance(importance) ?? true;
+
+    private void EndActivity(ActivityScope scope, bool completed)
+    {
+        lock (_activityLock)
+        {
+            if (_activityStack.Count > 0 && ReferenceEquals(_activityStack.Peek(), scope))
+            {
+                _activityStack.Pop();
+            }
+
+            // No outcome line unless the activity was explicitly completed (e.g. the work threw before Complete).
+            if (completed)
+            {
+                _log.LogMessage(
+                    MessageImportance.Normal,
+                    "{0}",
+                    FormatActivityLine(scope.Depth, scope.Title, scope.Elapsed, scope.OutcomeMessage));
+            }
+        }
+    }
+}

--- a/src/Buildvana.Sdk.Tasks/TaskLoggingHelperReporter.cs
+++ b/src/Buildvana.Sdk.Tasks/TaskLoggingHelperReporter.cs
@@ -38,7 +38,7 @@ internal sealed partial class TaskLoggingHelperReporter : IReporter
 {
     private readonly TaskLoggingHelper _log;
     private readonly EngineServices? _engineServices;
-    private readonly Lock _activityLock = new();
+    private readonly Lock _writeLock = new();
     private readonly Stack<ActivityScope> _activityStack = new();
 
     public TaskLoggingHelperReporter(TaskLoggingHelper log, IBuildEngine engine)
@@ -57,32 +57,35 @@ internal sealed partial class TaskLoggingHelperReporter : IReporter
     public void Report(MessageLevel level, string message)
     {
         ArgumentNullException.ThrowIfNull(message);
-        switch (level)
+        lock (_writeLock)
         {
-            case MessageLevel.Error:
-                _log.LogError("{0}", message);
-                break;
-            case MessageLevel.Warning:
-                _log.LogWarning("{0}", message);
-                break;
-            case MessageLevel.Info:
-                _log.LogMessage(MessageImportance.High, "{0}", message);
-                break;
-            case MessageLevel.Detail:
-                _log.LogMessage(MessageImportance.Normal, "{0}", message);
-                break;
-            case MessageLevel.Trace:
-                _log.LogMessage(MessageImportance.Low, "{0}", message);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(level), level, "Unknown message level.");
+            switch (level)
+            {
+                case MessageLevel.Error:
+                    _log.LogError("{0}", message);
+                    break;
+                case MessageLevel.Warning:
+                    _log.LogWarning("{0}", message);
+                    break;
+                case MessageLevel.Info:
+                    _log.LogMessage(MessageImportance.High, "{0}", message);
+                    break;
+                case MessageLevel.Detail:
+                    _log.LogMessage(MessageImportance.Normal, "{0}", message);
+                    break;
+                case MessageLevel.Trace:
+                    _log.LogMessage(MessageImportance.Low, "{0}", message);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(level), level, "Unknown message level.");
+            }
         }
     }
 
     public IActivityScope BeginActivity(string title)
     {
         ArgumentException.ThrowIfNullOrEmpty(title);
-        lock (_activityLock)
+        lock (_writeLock)
         {
             var depth = _activityStack.Count + 1;
             var scope = new ActivityScope(this, title, depth);
@@ -123,12 +126,15 @@ internal sealed partial class TaskLoggingHelperReporter : IReporter
             return;
         }
 
-        _log.LogMessage(MessageImportance.Low, "{0}", line);
+        lock (_writeLock)
+        {
+            _log.LogMessage(MessageImportance.Low, "{0}", line);
+        }
     }
 
     private void EndActivity(ActivityScope scope, bool completed)
     {
-        lock (_activityLock)
+        lock (_writeLock)
         {
             if (_activityStack.Count > 0 && ReferenceEquals(_activityStack.Peek(), scope))
             {

--- a/src/Buildvana.Sdk.Tasks/TaskLoggingHelperReporter.cs
+++ b/src/Buildvana.Sdk.Tasks/TaskLoggingHelperReporter.cs
@@ -95,27 +95,9 @@ internal sealed partial class TaskLoggingHelperReporter : IReporter
         }
     }
 
-    public void ChildOutput(string line, Verbosity? minimumVerbosity)
-    {
-        ArgumentNullException.ThrowIfNull(line);
-        if (minimumVerbosity is { } v && !this.IsVerbosityAtLeast(v))
-        {
-            return;
-        }
+    public void ChildOutput(string line, Verbosity? minimumVerbosity) => LogChildLine(line, minimumVerbosity);
 
-        _log.LogMessage(MessageImportance.Low, "{0}", line);
-    }
-
-    public void ChildError(string line, Verbosity? minimumVerbosity)
-    {
-        ArgumentNullException.ThrowIfNull(line);
-        if (minimumVerbosity is { } v && !this.IsVerbosityAtLeast(v))
-        {
-            return;
-        }
-
-        _log.LogMessage(MessageImportance.Low, "{0}", line);
-    }
+    public void ChildError(string line, Verbosity? minimumVerbosity) => LogChildLine(line, minimumVerbosity);
 
     // Same line format as ConsoleReporter, so activities look the same whether a service runs under `bv` or MSBuild.
     private static string FormatActivityLine(int depth, string title, TimeSpan? elapsed, string? outcomeMessage)
@@ -132,6 +114,17 @@ internal sealed partial class TaskLoggingHelperReporter : IReporter
 
     private bool LogsMessagesOfImportance(MessageImportance importance)
         => _engineServices?.LogsMessagesOfImportance(importance) ?? true;
+
+    private void LogChildLine(string line, Verbosity? minimumVerbosity)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+        if (minimumVerbosity is { } v && !this.IsVerbosityAtLeast(v))
+        {
+            return;
+        }
+
+        _log.LogMessage(MessageImportance.Low, "{0}", line);
+    }
 
     private void EndActivity(ActivityScope scope, bool completed)
     {

--- a/src/Buildvana.Sdk.Tasks/Tasks/BuildvanaSdkTask.cs
+++ b/src/Buildvana.Sdk.Tasks/Tasks/BuildvanaSdkTask.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Buildvana.Core;
+using Buildvana.Core.ConsoleOutput;
 using Buildvana.Sdk.Internal;
 using Microsoft.Build.Utilities;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
@@ -12,6 +13,8 @@ namespace Buildvana.Sdk.Tasks;
 public abstract class BuildvanaSdkTask : Task
 {
     protected ILogger Logger => field ??= new TaskLoggingHelperLogger(Log, BuildEngine);
+
+    protected IReporter Reporter => field ??= new TaskLoggingHelperReporter(Log, BuildEngine);
 
     public sealed override bool Execute()
     {

--- a/tests/Buildvana.Sdk.Tasks.Tests/Buildvana.Sdk.Tasks.Tests.csproj
+++ b/tests/Buildvana.Sdk.Tasks.Tests/Buildvana.Sdk.Tasks.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>$(StandardTfm)</TargetFramework>
+    <ClsCompliant>false</ClsCompliant>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Unlike the project under test (which gets them from the MSBuild host at run time), tests need the MSBuild assemblies at run time, so no ExcludeAssets here. -->
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="TUnit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Buildvana.Sdk.Tasks\Buildvana.Sdk.Tasks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Buildvana.Sdk.Tasks.Tests/RecordingBuildEngine.cs
+++ b/tests/Buildvana.Sdk.Tasks.Tests/RecordingBuildEngine.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections;
+using Microsoft.Build.Framework;
+
+/// <summary>
+/// An <see cref="IBuildEngine"/> that records logged events for assertion.
+/// </summary>
+internal class RecordingBuildEngine : IBuildEngine
+{
+    private readonly List<BuildErrorEventArgs> _errors = [];
+
+    private readonly List<BuildWarningEventArgs> _warnings = [];
+
+    private readonly List<BuildMessageEventArgs> _messages = [];
+
+    private readonly List<CustomBuildEventArgs> _customEvents = [];
+
+    public IReadOnlyList<BuildErrorEventArgs> Errors => _errors;
+
+    public IReadOnlyList<BuildWarningEventArgs> Warnings => _warnings;
+
+    public IReadOnlyList<BuildMessageEventArgs> Messages => _messages;
+
+    public IReadOnlyList<CustomBuildEventArgs> CustomEvents => _customEvents;
+
+    public bool ContinueOnError => false;
+
+    public int LineNumberOfTaskNode => 0;
+
+    public int ColumnNumberOfTaskNode => 0;
+
+    public string ProjectFileOfTaskNode => string.Empty;
+
+    public void LogErrorEvent(BuildErrorEventArgs? e)
+    {
+        ArgumentNullException.ThrowIfNull(e);
+        _errors.Add(e);
+    }
+
+    public void LogWarningEvent(BuildWarningEventArgs? e)
+    {
+        ArgumentNullException.ThrowIfNull(e);
+        _warnings.Add(e);
+    }
+
+    public void LogMessageEvent(BuildMessageEventArgs? e)
+    {
+        ArgumentNullException.ThrowIfNull(e);
+        _messages.Add(e);
+    }
+
+    public void LogCustomEvent(CustomBuildEventArgs? e)
+    {
+        ArgumentNullException.ThrowIfNull(e);
+        _customEvents.Add(e);
+    }
+
+    public bool BuildProjectFile(
+        string? projectFileName,
+        string[]? targetNames,
+        IDictionary? globalProperties,
+        IDictionary? targetOutputs)
+        => throw new NotSupportedException();
+}

--- a/tests/Buildvana.Sdk.Tasks.Tests/RecordingBuildEngine10.cs
+++ b/tests/Buildvana.Sdk.Tasks.Tests/RecordingBuildEngine10.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.ObjectModel;
+using Microsoft.Build.Framework;
+
+/// <summary>
+/// A <see cref="RecordingBuildEngine"/> that also implements <see cref="IBuildEngine10"/>, so that
+/// <see cref="IBuildEngine10.EngineServices"/> (and with it importance-based filtering) is available.
+/// Members that are irrelevant to the tests are benign no-ops; project-building members throw.
+/// </summary>
+internal sealed class RecordingBuildEngine10 : RecordingBuildEngine, IBuildEngine10
+{
+    public bool IsRunningMultipleNodes => false;
+
+    public bool AllowFailureWithoutError { get; set; }
+
+    public EngineServices EngineServices { get; init; } = new StubEngineServices();
+
+    public bool BuildProjectFile(
+        string? projectFileName,
+        string[]? targetNames,
+        IDictionary? globalProperties,
+        IDictionary? targetOutputs,
+        string? toolsVersion)
+        => throw new NotSupportedException();
+
+    public bool BuildProjectFilesInParallel(
+        string[]? projectFileNames,
+        string[]? targetNames,
+        IDictionary[]? globalProperties,
+        IDictionary[]? targetOutputsPerProject,
+        string[]? toolsVersion,
+        bool useResultsCache,
+        bool unloadProjectsOnCompletion)
+        => throw new NotSupportedException();
+
+    public BuildEngineResult BuildProjectFilesInParallel(
+        string[]? projectFileNames,
+        string[]? targetNames,
+        IDictionary[]? globalProperties,
+        IList<string>[]? removeGlobalProperties,
+        string[]? toolsVersion,
+        bool returnTargetOutputs)
+        => throw new NotSupportedException();
+
+    public void Yield()
+    {
+    }
+
+    public void Reacquire()
+    {
+    }
+
+    public void RegisterTaskObject(
+        object? key,
+        object? obj,
+        RegisteredTaskObjectLifetime lifetime,
+        bool allowEarlyCollection)
+    {
+    }
+
+    public object? GetRegisteredTaskObject(object? key, RegisteredTaskObjectLifetime lifetime) => null;
+
+    public object? UnregisterTaskObject(object? key, RegisteredTaskObjectLifetime lifetime) => null;
+
+    public void LogTelemetry(string? eventName, IDictionary<string, string>? properties)
+    {
+    }
+
+    public IReadOnlyDictionary<string, string> GetGlobalProperties() => ReadOnlyDictionary<string, string>.Empty;
+
+    public bool ShouldTreatWarningAsError(string? warningCode) => false;
+
+    public int RequestCores(int requestedCores) => requestedCores;
+
+    public void ReleaseCores(int coresToRelease)
+    {
+    }
+}

--- a/tests/Buildvana.Sdk.Tasks.Tests/ReporterProbeTask.cs
+++ b/tests/Buildvana.Sdk.Tasks.Tests/ReporterProbeTask.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core.ConsoleOutput;
+using Buildvana.Sdk;
+using Buildvana.Sdk.Tasks;
+
+/// <summary>
+/// A do-nothing <see cref="BuildvanaSdkTask"/> that exposes the protected
+/// <see cref="BuildvanaSdkTask.Reporter"/> property to tests.
+/// </summary>
+internal sealed class ReporterProbeTask : BuildvanaSdkTask
+{
+    public IReporter ExposedReporter => Reporter;
+
+    protected override Undefined Run() => Undefined.Value;
+}

--- a/tests/Buildvana.Sdk.Tasks.Tests/StubEngineServices.cs
+++ b/tests/Buildvana.Sdk.Tasks.Tests/StubEngineServices.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Build.Framework;
+
+/// <summary>
+/// An <see cref="EngineServices"/> whose importance filtering is controlled by
+/// <see cref="MinimumImportance"/>: the least important level still logged, or
+/// <see langword="null"/> to log nothing at all.
+/// </summary>
+internal sealed class StubEngineServices : EngineServices
+{
+    public MessageImportance? MinimumImportance { get; init; } = MessageImportance.Low;
+
+    public override bool LogsMessagesOfImportance(MessageImportance importance)
+        => MinimumImportance is { } minimum && (int)importance <= (int)minimum;
+}

--- a/tests/Buildvana.Sdk.Tasks.Tests/TaskLoggingHelperReporterTests.cs
+++ b/tests/Buildvana.Sdk.Tasks.Tests/TaskLoggingHelperReporterTests.cs
@@ -2,10 +2,25 @@
 // See the LICENSE file in the project root for full license information.
 
 using Buildvana.Core.ConsoleOutput;
+using Buildvana.Sdk;
 using Microsoft.Build.Framework;
 
 internal sealed class TaskLoggingHelperReporterTests
 {
+    [Test]
+    public async Task Constructor_NullLog_Throws()
+    {
+        var engine = new RecordingBuildEngine();
+        await Assert.That(() => new TaskLoggingHelperReporter(null!, engine)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task Constructor_NullEngine_Throws()
+    {
+        var task = new ReporterProbeTask { BuildEngine = new RecordingBuildEngine() };
+        await Assert.That(() => new TaskLoggingHelperReporter(task.Log, null!)).Throws<ArgumentNullException>();
+    }
+
     [Test]
     public async Task Report_Error_LogsBuildError()
     {
@@ -50,6 +65,13 @@ internal sealed class TaskLoggingHelperReporterTests
     {
         var (reporter, _) = CreateReporter();
         await Assert.That(() => reporter.Report((MessageLevel)42, "x")).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Report_NullMessage_Throws()
+    {
+        var (reporter, _) = CreateReporter();
+        await Assert.That(() => reporter.Report(MessageLevel.Info, null!)).Throws<ArgumentNullException>();
     }
 
     [Test]
@@ -116,6 +138,34 @@ internal sealed class TaskLoggingHelperReporterTests
         await Assert.That(engine.Messages.Count).IsEqualTo(3);
         await Assert.That(engine.Messages[1].Message).IsEqualTo("[2] Inner: starting...");
         await Assert.That(engine.Messages[2].Message).StartsWith("[2] Inner: done (");
+    }
+
+    [Test]
+    public async Task BeginActivity_NullTitle_Throws()
+    {
+        var (reporter, _) = CreateReporter();
+        await Assert.That(() => reporter.BeginActivity(null!)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task BeginActivity_EmptyTitle_Throws()
+    {
+        var (reporter, _) = CreateReporter();
+        await Assert.That(() => reporter.BeginActivity(string.Empty)).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task ChildOutput_NullLine_Throws()
+    {
+        var (reporter, _) = CreateReporter();
+        await Assert.That(() => reporter.ChildOutput(null!, null)).Throws<ArgumentNullException>();
+    }
+
+    [Test]
+    public async Task ChildError_NullLine_Throws()
+    {
+        var (reporter, _) = CreateReporter();
+        await Assert.That(() => reporter.ChildError(null!, null)).Throws<ArgumentNullException>();
     }
 
     [Test]

--- a/tests/Buildvana.Sdk.Tasks.Tests/TaskLoggingHelperReporterTests.cs
+++ b/tests/Buildvana.Sdk.Tasks.Tests/TaskLoggingHelperReporterTests.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Buildvana.Core.ConsoleOutput;
+using Microsoft.Build.Framework;
+
+internal sealed class TaskLoggingHelperReporterTests
+{
+    [Test]
+    public async Task Report_Error_LogsBuildError()
+    {
+        var (reporter, engine) = CreateReporter();
+        reporter.Report(MessageLevel.Error, "boom");
+        await Assert.That(engine.Errors.Count).IsEqualTo(1);
+        await Assert.That(engine.Errors[0].Message).IsEqualTo("boom");
+        await Assert.That(engine.Warnings.Count).IsEqualTo(0);
+        await Assert.That(engine.Messages.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Report_Warning_LogsBuildWarning()
+    {
+        var (reporter, engine) = CreateReporter();
+        reporter.Report(MessageLevel.Warning, "uh-oh");
+        await Assert.That(engine.Warnings.Count).IsEqualTo(1);
+        await Assert.That(engine.Warnings[0].Message).IsEqualTo("uh-oh");
+        await Assert.That(engine.Errors.Count).IsEqualTo(0);
+        await Assert.That(engine.Messages.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(MessageLevel.Info, MessageImportance.High)]
+    [Arguments(MessageLevel.Detail, MessageImportance.Normal)]
+    [Arguments(MessageLevel.Trace, MessageImportance.Low)]
+    public async Task Report_MessageLevel_LogsMessageWithExpectedImportance(
+        MessageLevel level,
+        MessageImportance expectedImportance)
+    {
+        var (reporter, engine) = CreateReporter();
+        reporter.Report(level, "hello");
+        await Assert.That(engine.Messages.Count).IsEqualTo(1);
+        await Assert.That(engine.Messages[0].Message).IsEqualTo("hello");
+        await Assert.That(engine.Messages[0].Importance).IsEqualTo(expectedImportance);
+        await Assert.That(engine.Errors.Count).IsEqualTo(0);
+        await Assert.That(engine.Warnings.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Report_UnknownLevel_Throws()
+    {
+        var (reporter, _) = CreateReporter();
+        await Assert.That(() => reporter.Report((MessageLevel)42, "x")).Throws<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public async Task Verbosity_WithoutEngineServices_IsDiagnostic()
+    {
+        var (reporter, _) = CreateReporter();
+        await Assert.That(reporter.Verbosity).IsEqualTo(Verbosity.Diagnostic);
+    }
+
+    [Test]
+    [Arguments(MessageImportance.Low, Verbosity.Diagnostic)]
+    [Arguments(MessageImportance.Normal, Verbosity.Detailed)]
+    [Arguments(MessageImportance.High, Verbosity.Normal)]
+    [Arguments(null, Verbosity.Minimal)]
+    public async Task Verbosity_WithEngineServices_TracksImportanceFiltering(
+        MessageImportance? minimumImportance,
+        Verbosity expectedVerbosity)
+    {
+        var (reporter, _) = CreateReporter(minimumImportance);
+        await Assert.That(reporter.Verbosity).IsEqualTo(expectedVerbosity);
+    }
+
+    [Test]
+    public async Task BeginActivity_LogsStartLine()
+    {
+        var (reporter, engine) = CreateReporter();
+        using var scope = reporter.BeginActivity("Frobbing");
+        await Assert.That(engine.Messages.Count).IsEqualTo(1);
+        await Assert.That(engine.Messages[0].Message).IsEqualTo("[1] Frobbing: starting...");
+        await Assert.That(engine.Messages[0].Importance).IsEqualTo(MessageImportance.Normal);
+    }
+
+    [Test]
+    public async Task ActivityScope_CompleteThenDispose_LogsOutcomeLine()
+    {
+        var (reporter, engine) = CreateReporter();
+        var scope = reporter.BeginActivity("Frobbing");
+        scope.Complete("all good");
+        scope.Dispose();
+        await Assert.That(engine.Messages.Count).IsEqualTo(2);
+        await Assert.That(engine.Messages[1].Message).StartsWith("[1] Frobbing: done (");
+        await Assert.That(engine.Messages[1].Message).EndsWith(" - all good");
+        await Assert.That(engine.Messages[1].Importance).IsEqualTo(MessageImportance.Normal);
+    }
+
+    [Test]
+    public async Task ActivityScope_DisposeWithoutComplete_LogsNoOutcomeLine()
+    {
+        var (reporter, engine) = CreateReporter();
+        var scope = reporter.BeginActivity("Frobbing");
+        scope.Dispose();
+        scope.Dispose();
+        await Assert.That(engine.Messages.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task BeginActivity_Nested_TracksDepth()
+    {
+        var (reporter, engine) = CreateReporter();
+        using var outer = reporter.BeginActivity("Outer");
+        var inner = reporter.BeginActivity("Inner");
+        inner.Complete();
+        inner.Dispose();
+        await Assert.That(engine.Messages.Count).IsEqualTo(3);
+        await Assert.That(engine.Messages[1].Message).IsEqualTo("[2] Inner: starting...");
+        await Assert.That(engine.Messages[2].Message).StartsWith("[2] Inner: done (");
+    }
+
+    [Test]
+    public async Task ChildOutput_LogsLowImportanceMessage()
+    {
+        var (reporter, engine) = CreateReporter();
+        reporter.ChildOutput("raw stdout line", null);
+        await Assert.That(engine.Messages.Count).IsEqualTo(1);
+        await Assert.That(engine.Messages[0].Message).IsEqualTo("raw stdout line");
+        await Assert.That(engine.Messages[0].Importance).IsEqualTo(MessageImportance.Low);
+    }
+
+    [Test]
+    public async Task ChildError_LogsLowImportanceMessage_NotABuildError()
+    {
+        var (reporter, engine) = CreateReporter();
+        reporter.ChildError("raw stderr line", null);
+        await Assert.That(engine.Errors.Count).IsEqualTo(0);
+        await Assert.That(engine.Warnings.Count).IsEqualTo(0);
+        await Assert.That(engine.Messages.Count).IsEqualTo(1);
+        await Assert.That(engine.Messages[0].Message).IsEqualTo("raw stderr line");
+        await Assert.That(engine.Messages[0].Importance).IsEqualTo(MessageImportance.Low);
+    }
+
+    [Test]
+    public async Task ChildLines_WhenEngineDiscardsLowImportance_AreNotForwarded()
+    {
+        // Dropped twice over: the reporter's minimumVerbosity gate (verbosity here is Normal) and
+        // TaskLoggingHelper's own importance filtering both consult the same EngineServices.
+        var (reporter, engine) = CreateReporter(MessageImportance.High);
+        reporter.ChildOutput("out", null);
+        reporter.ChildOutput("out gated", Verbosity.Diagnostic);
+        reporter.ChildError("err", null);
+        reporter.ChildError("err gated", Verbosity.Diagnostic);
+        await Assert.That(engine.Messages.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ChildLines_WhenEngineLogsLowImportance_AreForwarded()
+    {
+        var (reporter, engine) = CreateReporter(MessageImportance.Low);
+        reporter.ChildOutput("out", Verbosity.Diagnostic);
+        reporter.ChildError("err", Verbosity.Diagnostic);
+        await Assert.That(engine.Messages.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Reporter_IsCachedPerTask()
+    {
+        var task = new ReporterProbeTask { BuildEngine = new RecordingBuildEngine() };
+        await Assert.That(task.ExposedReporter).IsSameReferenceAs(task.ExposedReporter);
+    }
+
+    private static (IReporter Reporter, RecordingBuildEngine Engine) CreateReporter()
+    {
+        var engine = new RecordingBuildEngine();
+        var task = new ReporterProbeTask { BuildEngine = engine };
+        return (task.ExposedReporter, engine);
+    }
+
+    private static (IReporter Reporter, RecordingBuildEngine Engine) CreateReporter(
+        MessageImportance? minimumImportance)
+    {
+        var engine = new RecordingBuildEngine10
+        {
+            EngineServices = new StubEngineServices { MinimumImportance = minimumImportance },
+        };
+        var task = new ReporterProbeTask { BuildEngine = engine };
+        return (task.ExposedReporter, engine);
+    }
+}


### PR DESCRIPTION
Closes #294.

Implements the plumbing for running Core services inside MSBuild tasks (design option (b) of #267): human-facing output flows through `IReporter`, bridged to the build's own loggers.

## Changes

- **`TaskLoggingHelperReporter`** (internal, `Buildvana.Sdk.Tasks`) — an `IReporter` backed by the task's `TaskLoggingHelper`, sibling to the existing `TaskLoggingHelperLogger` `ILogger` bridge:
  - `Report`: `Error` → `LogError`, `Warning` → `LogWarning`, `Info`/`Detail`/`Trace` → `LogMessage` at `High`/`Normal`/`Low` importance.
  - Activity scopes render the same `[depth] title: starting.../done (X.Xs)` lines as `ConsoleReporter` (outcome only after `Complete`), at `Normal` importance so they stay quiet at MSBuild's default (minimal) verbosity.
  - `ChildOutput`/`ChildError` both pass through as low-importance messages: MSBuild has no neutral stderr channel, and a build error would fail the task over stderr lines many tools use for progress.
  - `Verbosity` is derived from `IBuildEngine10.EngineServices` importance filtering when available (fully permissive fallback), so `ReporterExtensions` formatting helpers skip messages MSBuild would discard; MSBuild's own verbosity gating governs visibility either way.
- **`BuildvanaSdkTask`** exposes a lazily built `protected IReporter Reporter`, mirroring `Logger`, for derived tasks to hand to Core services. No task consumes it yet; existing tasks are unchanged.
- **Tests** — new `Buildvana.Sdk.Tasks.Tests` project (TUnit): a recording `IBuildEngine` (plus an `IBuildEngine10` variant with stubbed `EngineServices`) drives the full mapping through the real `Reporter` property of a probe task; 20 tests cover levels, importances, activity lifecycle, child passthrough, and verbosity derivation.

No CHANGELOG entry: internal-only, no public-facing change.

## Validation

- `dotnet build`: zero warnings/errors; all tests pass.
- `dotnet bv pack` self-hosts and produces the `Buildvana.Sdk` and `bv` packages.
- ReSharper `inspectcode` (`--swea --severity=WARNING`): no findings in changed code (one pre-existing false positive in `Buildvana.Core.JsonSchema`, untouched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)