### PR TITLE
Replace PolyKit.Embedded with PolySharp in Buildvana.Sdk.SourceGenerators

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,12 +48,12 @@
     <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
     <PackageVersion Include="NuGet.Versioning" Version="7.6.0" />
     <PackageVersion Include="Octokit" Version="14.0.0" />
-    <PackageVersion Include="PolyKit.Embedded" Version="3.0.27-preview" />
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
   </ItemGroup>
 
   <!-- Development dependencies-->
   <ItemGroup>
+    <PackageVersion Include="PolySharp" Version="1.16.0" />
   </ItemGroup>
 
   <!-- Test dependencies-->

--- a/src/Buildvana.Sdk.SourceGenerators/Buildvana.Sdk.SourceGenerators.csproj
+++ b/src/Buildvana.Sdk.SourceGenerators/Buildvana.Sdk.SourceGenerators.csproj
@@ -4,6 +4,11 @@
     <TargetFramework>$(SourceGeneratorsTfm)</TargetFramework>
     <CLSCompliant>false</CLSCompliant>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+
+    <!-- Restrict PolySharp to the polyfills this project actually uses; add types here as new needs arise.
+         Mind the polyfills' own dependencies (e.g. System.Index needs the nullable attributes, which would
+         collide with the BCL's in projects that see our internals through InternalsVisibleTo). -->
+    <PolySharpIncludeGeneratedTypes>System.Runtime.CompilerServices.IsExternalInit</PolySharpIncludeGeneratedTypes>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all" />
-    <PackageReference Include="PolyKit.Embedded" PrivateAssets="all" />
+    <PackageReference Include="PolySharp" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/Buildvana.Sdk.SourceGenerators/Internal/ConstantValueParser.cs
+++ b/src/Buildvana.Sdk.SourceGenerators/Internal/ConstantValueParser.cs
@@ -43,7 +43,7 @@ internal static class ConstantValueParser
             return true;
         }
 
-        if (str!.Length > 1 && str[0] == '"' && str[^1] == '"')
+        if (str!.Length > 1 && str[0] == '"' && str[str.Length - 1] == '"')
         {
             result = str.Substring(1, str.Length - 2).Replace("\"\"", "\"");
             return true;

--- a/tests/Buildvana.Sdk.SourceGenerators.Tests/Buildvana.Sdk.SourceGenerators.Tests.csproj
+++ b/tests/Buildvana.Sdk.SourceGenerators.Tests/Buildvana.Sdk.SourceGenerators.Tests.csproj
@@ -14,9 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- The alias keeps the project's internals (which include PolyKit polyfills, made visible by InternalsVisibleTo)
-         out of the global namespace, where they would clash with the framework's own types. -->
-    <ProjectReference Include="..\..\src\Buildvana.Sdk.SourceGenerators\Buildvana.Sdk.SourceGenerators.csproj" Aliases="Generators" />
+    <ProjectReference Include="..\..\src\Buildvana.Sdk.SourceGenerators\Buildvana.Sdk.SourceGenerators.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Buildvana.Sdk.SourceGenerators.Tests/ConstantValueParserTests.cs
+++ b/tests/Buildvana.Sdk.SourceGenerators.Tests/ConstantValueParserTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-extern alias Generators;
-
-using Generators::Buildvana.Sdk.SourceGenerators.Internal;
+using Buildvana.Sdk.SourceGenerators.Internal;
 
 internal sealed class ConstantValueParserTests
 {

--- a/tests/Buildvana.Sdk.SourceGenerators.Tests/ThisAssemblyClassGeneratorTests.cs
+++ b/tests/Buildvana.Sdk.SourceGenerators.Tests/ThisAssemblyClassGeneratorTests.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-extern alias Generators;
-
 using System.Globalization;
-using Generators::Buildvana.Sdk.SourceGenerators;
+using Buildvana.Sdk.SourceGenerators;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 


### PR DESCRIPTION
## Proposed changes

**WHY** — #305: `PolyKit.Embedded` is effectively unmaintained and injects far more polyfills than the repository's only `netstandard2.0` project needs. The excess internals leaked into the test project through `InternalsVisibleTo`, colliding with the same types in `System.Runtime` (CS0433) and forcing an extern-alias reference — a construct rare enough to be overlooked by maintainers, and one that had already triggered an in-IDE ReSharper false positive.

**WHERE** — `Buildvana.Sdk.SourceGenerators` (project file and one expression in `ConstantValueParser`), `Directory.Packages.props`, `Buildvana.Sdk.SourceGenerators.Tests`.

**WHAT** — `PolyKit.Embedded` is gone. [PolySharp](https://github.com/Sergio0694/PolySharp) 1.16.0 (`PrivateAssets="all"`, central version under development dependencies) provides polyfills, restricted via `PolySharpIncludeGeneratedTypes` to a single type: `IsExternalInit`, required by the project's one `readonly record struct`. The test project now references the generators project without `Aliases="Generators"`, and the two test files lose their `extern alias` directives. No consumer-visible changes; no CHANGELOG entry.

**HOW** — #305 prescribed polyfilling `System.Index` too, for the project's single `str[^1]` expression — but PolySharp's `Index` polyfill references `[NotNullWhen]` and `[DoesNotReturn]`, and PolySharp does not generate dependencies transitively. Polyfilling those attributes would have reintroduced, through `InternalsVisibleTo`, exactly the BCL collision that forced the extern alias (the test project itself uses `[NotNullWhen]`). Writing `str[str.Length - 1]` instead shrinks the injected surface to one type never named in source and lets the alias go for good. A comment on `PolySharpIncludeGeneratedTypes` warns future polyfill additions about this dependency fan-out.

Sanity check: `dotnet bv pack` clean (both packages produced), 51/51 source-generator tests green, `dotnet build` with zero warnings and zero errors; ReSharper inspectcode reports nothing in changed code (its single result is a pre-existing false positive in `Buildvana.Core.JsonSchema`, unrelated to this PR).

### Checklist of related issues / discussions

- [x] Fixes #305
- [ ] Partially fixes #
- [ ] Related discussion(s): #

## Types of changes

This pull request introduces the following types of changes:

- [ ] Bug fix
- [ ] New feature
- [ ] Test addition / update (no changes to non-test code)
- [x] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [x] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Other

### Breaking changes

This pull request introduces breaking changes:

- [ ] Yes
- [x] No

## Checklist

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] I have added tests that prove my feature works / my fix is effective
  - [x] I have added / modified XML documentation according to changes in code
  - [x] I have checked that all the links I added or modified in XML documentation point to their intended destination
- **For documentation changes (`docs` directory) only:**
  - [ ] I have built and tested documentation locally
  - [ ] I have checked that all the links I added or modified point to their intended destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)