### PR TITLE
Promote high-value analyzer hints to warnings

### DIFF
--- a/.claude/rules/csharp-style-guide.md
+++ b/.claude/rules/csharp-style-guide.md
@@ -48,7 +48,7 @@ Prefer pattern matching over equivalent chains of comparisons, type checks, and 
 Semantic differences to keep in mind when converting:
 
 - List, property, and recursive patterns imply a null test: `propertyPath is [PropertyName, PackageId]` is `false` when `propertyPath` is null, where `propertyPath.Count == 2` would throw. Usually an improvement, but it is a behavior change, not a pure rewrite.
-- Constant patterns compare with `Equals`, while `==` uses the type's equality operator. With `float` / `double` the pattern is what you want: `x is double.NaN` matches NaN, while `x == double.NaN` is always `false`. Exception: in the rare case of a type that overloads `==` with semantics that differ from `Equals` (so `x == null` and `x is null` disagree), keep the operator form.
+- Constant patterns never use the type's `==` operator. Non-null constants compare with `Equals`; `null` is a plain reference test (a `HasValue` check for nullable value types). With `float` / `double` the pattern is what you want: `x is double.NaN` matches NaN, while `x == double.NaN` is always `false`. Exception: in the rare case of a type that overloads `==` so that `x == null` and `x is null` disagree, keep the operator form.
 
 ## Partial classes
 

--- a/.claude/rules/csharp-style-guide.md
+++ b/.claude/rules/csharp-style-guide.md
@@ -24,6 +24,28 @@ Use latest C# features whenever possible. Non-exhaustive list of features to use
 - `field` keyword
 - Primary constructors
 - Extension blocks
+- Pattern matching (see below)
+
+## Pattern matching
+
+Prefer pattern matching over equivalent chains of comparisons, type checks, and casts: a pattern states the shape of the data, while a chain of checks makes the reader reassemble it. In particular:
+
+- List patterns over count checks + indexed comparisons:
+
+  ```csharp
+  // This is wrong
+  var isPinPath = propertyPath.Count == 2 && propertyPath[0] == PropertyName && propertyPath[1] == PackageId;
+
+  // This is correct
+  var isPinPath = propertyPath is [PropertyName, PackageId];
+  ```
+
+- `is T x` over `as` + null check, and over `is` check + cast.
+- Property patterns over chains of dotted comparisons: `result is { ExitCode: 0, StandardError.Length: 0 }`.
+- `is null` / `is not null` over `== null` / `!= null`.
+- Switch expressions over `if`/`else if` chains or switch statements whose branches produce a value.
+
+Exception: constant patterns compare with `Equals`, while `==` uses the type's equality operator. In the rare case of a type that overloads `==` with semantics that differ from `Equals`, keep the operator form.
 
 ## Partial classes
 

--- a/.claude/rules/csharp-style-guide.md
+++ b/.claude/rules/csharp-style-guide.md
@@ -45,7 +45,10 @@ Prefer pattern matching over equivalent chains of comparisons, type checks, and 
 - `is null` / `is not null` over `== null` / `!= null`.
 - Switch expressions over `if`/`else if` chains or switch statements whose branches produce a value.
 
-Exception: constant patterns compare with `Equals`, while `==` uses the type's equality operator. In the rare case of a type that overloads `==` with semantics that differ from `Equals`, keep the operator form.
+Semantic differences to keep in mind when converting:
+
+- List, property, and recursive patterns imply a null test: `propertyPath is [PropertyName, PackageId]` is `false` when `propertyPath` is null, where `propertyPath.Count == 2` would throw. Usually an improvement, but it is a behavior change, not a pure rewrite.
+- Constant patterns compare with `Equals`, while `==` uses the type's equality operator. With `float` / `double` the pattern is what you want: `x is double.NaN` matches NaN, while `x == double.NaN` is always `false`. Exception: in the rare case of a type that overloads `==` with semantics that differ from `Equals` (so `x == null` and `x is null` disagree), keep the operator form.
 
 ## Partial classes
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -110,7 +110,6 @@ dotnet_style_object_initializer = true:suggestion
 dotnet_style_operator_placement_when_wrapping = beginning_of_line:suggestion
 dotnet_style_prefer_auto_properties = true:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
 dotnet_style_prefer_conditional_expression_over_return = false:suggestion
 dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -116,7 +116,7 @@ dotnet_style_prefer_conditional_expression_over_return = false:suggestion
 dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
 
@@ -154,12 +154,13 @@ csharp_style_expression_bodied_operators = when_on_single_line:suggestion
 csharp_style_expression_bodied_properties = true:suggestion
 
 # Pattern matching preferences
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+# Pattern matching is preferred over equivalent comparison / type-check / cast chains: see .claude/rules/csharp-style-guide.md.
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_prefer_extended_property_pattern = true:suggestion
-csharp_style_prefer_not_pattern = true:suggestion
-csharp_style_prefer_pattern_matching = true:suggestion
-csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_not_pattern = true:warning
+csharp_style_prefer_pattern_matching = true:warning
+csharp_style_prefer_switch_expression = true:warning
 
 # Null-checking preferences
 csharp_style_conditional_delegate_call = true:suggestion
@@ -183,7 +184,7 @@ csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_prefer_index_operator = true:suggestion
 csharp_style_prefer_local_over_anonymous_function = true:warning
-csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:warning
 csharp_style_prefer_range_operator = true:suggestion
 csharp_style_prefer_tuple_swap = true:suggestion
 csharp_style_prefer_utf8_string_literals = true:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -171,9 +171,9 @@ csharp_style_prefer_readonly_struct = true:suggestion
 csharp_style_prefer_readonly_struct_member = true:suggestion
 
 # Code-block preferences
-csharp_prefer_braces = true:suggestion
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_prefer_braces = true:warning
+csharp_prefer_simple_using_statement = true:warning
+csharp_style_prefer_method_group_conversion = true:warning
 csharp_style_prefer_top_level_statements = false
 
 # Expression-level preferences
@@ -182,7 +182,7 @@ csharp_style_deconstructed_variable_declaration = true:suggestion
 csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:warning
 csharp_style_prefer_null_check_over_type_check = true:suggestion
 csharp_style_prefer_range_operator = true:suggestion
 csharp_style_prefer_tuple_swap = true:suggestion
@@ -536,7 +536,7 @@ dotnet_diagnostic.IDE0290.severity = none # Use primary constructor - No. Just n
 
 # Solution-specific overrides
 
-# Some types and memberts are unused but present for completeness and/or future use, or instantiated via DI.
+# Some types and members are unused but present for completeness and/or future use, or instantiated via DI.
 # We don't need to flag every unused type or member: sprinkling PublicAPI and/or UsedImplicitly attributes around would be mostly noise.
 resharper_class_never_instantiated_global_highlighting = none
 resharper_unused_type_global_highlighting = none
@@ -548,3 +548,18 @@ resharper_member_can_be_private_global_highlighting = none
 # Disabling these rules globally helps keep code clean and simple without needing to sprinkle pragmas or suppression attributes around the codebase.
 dotnet_diagnostic.CA1848.severity = none
 dotnet_diagnostic.CA1873.severity = none
+
+# Promote selected ReSharper hints to warnings, so that the inspectcode gate (which runs with --severity=WARNING) enforces them.
+
+# Pattern matching is preferred over equivalent comparison / type-check / cast chains: see .claude/rules/csharp-style-guide.md.
+resharper_merge_into_pattern_highlighting = warning
+resharper_use_pattern_matching_highlighting = warning
+resharper_merge_cast_with_type_check_highlighting = warning
+
+# Modernizations that are essentially always improvements.
+resharper_use_await_using_highlighting = warning
+resharper_use_utf8_string_literal_highlighting = warning
+resharper_can_simplify_dictionary_try_get_value_with_get_value_or_default_highlighting = warning
+resharper_convert_closure_to_method_group_highlighting = warning
+resharper_convert_to_local_function_highlighting = warning
+resharper_property_can_be_made_init_only_global_highlighting = warning

--- a/src/Buildvana.Core.Abstractions/Json/IJsonHelper.cs
+++ b/src/Buildvana.Core.Abstractions/Json/IJsonHelper.cs
@@ -32,6 +32,7 @@ public interface IJsonHelper
     /// </summary>
     /// <param name="json">The JSON object to save.</param>
     /// <param name="path">The path of the file to save <paramref name="json"/> to.</param>
+    // ReSharper disable once UnusedMemberInSuper.Global // SaveObject is half of the load/save contract, so it stays, even if it has no current usage.
     void SaveObject(JsonNode json, string path);
 
     /// <summary>

--- a/src/Buildvana.Core.Process/ProcessRunner.cs
+++ b/src/Buildvana.Core.Process/ProcessRunner.cs
@@ -142,8 +142,8 @@ public sealed class ProcessRunner : IProcessRunner
 
         // Keep this process alive across Ctrl-C: the child shares the console and receives the same signal;
         // it owns its shutdown, and this process must survive to observe and report the exit code.
-        ConsoleCancelEventHandler suppressCancel = static (_, e) => e.Cancel = true;
-        Console.CancelKeyPress += suppressCancel;
+        static void SuppressCancel(object? sender, ConsoleCancelEventArgs e) => e.Cancel = true;
+        Console.CancelKeyPress += SuppressCancel;
         try
         {
             using var process = StartProcess(startInfo);
@@ -161,7 +161,7 @@ public sealed class ProcessRunner : IProcessRunner
         }
         finally
         {
-            Console.CancelKeyPress -= suppressCancel;
+            Console.CancelKeyPress -= SuppressCancel;
         }
     }
 

--- a/src/Buildvana.Core.Testing/FakeProcessRunner.cs
+++ b/src/Buildvana.Core.Testing/FakeProcessRunner.cs
@@ -34,13 +34,13 @@ public sealed class FakeProcessRunner : IProcessRunner
     /// <see cref="ProcessResult.StandardOutput"/> and <see cref="ProcessResult.StandardError"/> are replayed,
     /// line by line, through the caller's <c>onStdout</c>/<c>onStderr</c> callbacks, like the real runner streams them.
     /// </summary>
-    public Func<string, IReadOnlyList<string>, ProcessResult>? OnRun { get; set; }
+    public Func<string, IReadOnlyList<string>, ProcessResult>? OnRun { get; init; }
 
     /// <summary>
     /// Gets or sets a callback that produces the exit code of each <see cref="RunWithInheritedStdioAsync"/>
     /// invocation, simulating the process's behavior. When <see langword="null"/>, every invocation returns 0.
     /// </summary>
-    public Func<string, IReadOnlyList<string>, int>? OnRunWithInheritedStdio { get; set; }
+    public Func<string, IReadOnlyList<string>, int>? OnRunWithInheritedStdio { get; init; }
 
     /// <inheritdoc/>
     public Task<ProcessResult> RunAsync(

--- a/src/Buildvana.Sdk.Tasks/.editorconfig
+++ b/src/Buildvana.Sdk.Tasks/.editorconfig
@@ -4,5 +4,7 @@ root = false
 
 [*.cs]
 
-# Task properties are set by the build engine, not in our code. "Unused" getters are not a concern.
+# Task properties are set by the build engine via reflection, not in our code: neither "unused" getters
+# nor "never mutated" setters say anything about the real contract.
 resharper_auto_property_can_be_made_get_only_global_highlighting = none
+resharper_property_can_be_made_init_only_global_highlighting = none

--- a/src/Buildvana.Tool/Infrastructure/Execution/CommandNode.cs
+++ b/src/Buildvana.Tool/Infrastructure/Execution/CommandNode.cs
@@ -60,7 +60,7 @@ internal sealed class CommandNode
     public CommandNode? FindChild(string name)
     {
         Guard.IsNotNullOrEmpty(name);
-        return _children.TryGetValue(name, out var child) ? child : null;
+        return _children.GetValueOrDefault(name);
     }
 
     internal CommandNode GetOrAddChild(string name)

--- a/src/Buildvana.Tool/Services/SelfVersionService.cs
+++ b/src/Buildvana.Tool/Services/SelfVersionService.cs
@@ -201,7 +201,7 @@ internal sealed partial class SelfVersionService
     }
 
     private static bool IsPinPath(IReadOnlyList<string> propertyPath)
-        => propertyPath.Count == 2 && propertyPath[0] == MsbuildSdksPropertyName && propertyPath[1] == SdkPackageId;
+        => propertyPath is [MsbuildSdksPropertyName, SdkPackageId];
 
     // The update never downgrades silently: an old bv run by habit in a newer repository must not roll the
     // repository back. `dotnet bv update` runs the repository's own pinned bv (the update command is exempt

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -6,3 +6,25 @@ root = false
 
 # Test methods can have compound or expression bodies, as appropriate for the test.
 resharper_arrange_method_or_operator_body_highlighting = none
+
+# TUnit test methods must be public instance methods, so "member can be made static" is a trap here.
+resharper_member_can_be_made_static_global_highlighting = none
+
+# Local functions go wherever they make the test easiest to read, free of placement and separation rules
+resharper_move_local_function_after_jump_statement_highlighting = none
+resharper_separate_local_functions_with_jump_statement_highlighting = none
+
+# new Type() (as opposed to new()) is often clearer in tests.
+resharper_arrange_object_creation_when_type_evident_highlighting = none
+
+# Declare types in namespaces - test projects have no root namespace on purpose (see Common.targets)
+dotnet_diagnostic.CA1050.severity = none
+
+# Identifiers should not contain underscores - underscores are the test naming convention
+dotnet_diagnostic.CA1707.severity = none
+
+# Expression value is never used - a test method may call a method for its side effects, and not use the return value
+dotnet_diagnostic.IDE0058.severity = none
+
+# Elements should be documented - test code is self-describing
+dotnet_diagnostic.SA1600.severity = none

--- a/tests/Buildvana.Core.IO.Tests/UserDirectoryTests.cs
+++ b/tests/Buildvana.Core.IO.Tests/UserDirectoryTests.cs
@@ -212,7 +212,7 @@ internal sealed class UserDirectoryTests
     {
         static IReadOnlyList<string> Act() => UserDirectory.EnumerateFiles(null!, "*.nupkg");
 
-        await Assert.That((Func<IReadOnlyList<string>>)Act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]
@@ -220,7 +220,7 @@ internal sealed class UserDirectoryTests
     {
         static IReadOnlyList<string> Act() => UserDirectory.EnumerateFiles(Path.GetTempPath(), null!);
 
-        await Assert.That((Func<IReadOnlyList<string>>)Act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]

--- a/tests/Buildvana.Core.IO.Tests/UserDirectoryTests.cs
+++ b/tests/Buildvana.Core.IO.Tests/UserDirectoryTests.cs
@@ -35,9 +35,9 @@ internal sealed class UserDirectoryTests
         await File.WriteAllTextAsync(path, string.Empty).ConfigureAwait(false);
         try
         {
-            var act = () => UserDirectory.CreateDirectory(path);
+            DirectoryInfo Act() => UserDirectory.CreateDirectory(path);
 
-            var exception = await Assert.That(act).Throws<BuildFailedException>();
+            var exception = await Assert.That(Act).Throws<BuildFailedException>();
             await Assert.That(exception!.Message).Contains("Could not create directory");
             await Assert.That(exception.InnerException).IsTypeOf<IOException>();
         }
@@ -50,9 +50,9 @@ internal sealed class UserDirectoryTests
     [Test]
     public async Task CreateDirectory_WithNullPath_ThrowsRaw()
     {
-        var act = () => UserDirectory.CreateDirectory(null!);
+        static DirectoryInfo Act() => UserDirectory.CreateDirectory(null!);
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]
@@ -75,9 +75,9 @@ internal sealed class UserDirectoryTests
         await File.WriteAllTextAsync(Path.Combine(root, "file.tmp"), string.Empty).ConfigureAwait(false);
         try
         {
-            var act = () => UserDirectory.Delete(root);
+            void Act() => UserDirectory.Delete(root);
 
-            var exception = await Assert.That(act).Throws<BuildFailedException>();
+            var exception = await Assert.That(Act).Throws<BuildFailedException>();
             await Assert.That(exception!.Message).Contains("Could not delete directory");
             await Assert.That(exception.InnerException).IsTypeOf<IOException>();
         }
@@ -92,9 +92,9 @@ internal sealed class UserDirectoryTests
     {
         var path = Path.Combine(Path.GetTempPath(), $"bv-test-{Guid.NewGuid():N}");
 
-        var act = () => UserDirectory.Delete(path);
+        void Act() => UserDirectory.Delete(path);
 
-        var exception = await Assert.That(act).Throws<BuildFailedException>();
+        var exception = await Assert.That(Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not delete directory");
         await Assert.That(exception.InnerException).IsTypeOf<DirectoryNotFoundException>();
     }
@@ -114,9 +114,9 @@ internal sealed class UserDirectoryTests
     [Test]
     public async Task Delete_WithNullPath_ThrowsRaw()
     {
-        var act = () => UserDirectory.Delete(null!);
+        static void Act() => UserDirectory.Delete(null!);
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]
@@ -164,9 +164,9 @@ internal sealed class UserDirectoryTests
     [Test]
     public async Task DeleteIfExists_WithNullPath_ThrowsRaw()
     {
-        var act = () => UserDirectory.DeleteIfExists(null!);
+        static void Act() => UserDirectory.DeleteIfExists(null!);
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]
@@ -210,17 +210,17 @@ internal sealed class UserDirectoryTests
     [Test]
     public async Task EnumerateFiles_WithNullBaseDirectory_ThrowsRaw()
     {
-        var act = () => UserDirectory.EnumerateFiles(null!, "*.nupkg");
+        static IReadOnlyList<string> Act() => UserDirectory.EnumerateFiles(null!, "*.nupkg");
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That((Func<IReadOnlyList<string>>)Act).Throws<ArgumentNullException>();
     }
 
     [Test]
     public async Task EnumerateFiles_WithNullPattern_ThrowsRaw()
     {
-        var act = () => UserDirectory.EnumerateFiles(Path.GetTempPath(), null!);
+        static IReadOnlyList<string> Act() => UserDirectory.EnumerateFiles(Path.GetTempPath(), null!);
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That((Func<IReadOnlyList<string>>)Act).Throws<ArgumentNullException>();
     }
 
     [Test]
@@ -234,8 +234,8 @@ internal sealed class UserDirectoryTests
     [Test]
     public async Task Exists_WithNullPath_ThrowsRaw()
     {
-        var act = () => UserDirectory.Exists(null!);
+        static bool Act() => UserDirectory.Exists(null!);
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 }

--- a/tests/Buildvana.Core.IO.Tests/UserFileTests.cs
+++ b/tests/Buildvana.Core.IO.Tests/UserFileTests.cs
@@ -142,7 +142,7 @@ internal sealed partial class UserFileTests
     [Test]
     public async Task ReadAllText_WithMalformedPath_Fails()
     {
-        string Act() => UserFile.ReadAllText("a\0b");
+        static string Act() => UserFile.ReadAllText("a\0b");
 
         var exception = await Assert.That(Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not read from");
@@ -166,7 +166,7 @@ internal sealed partial class UserFileTests
     {
         static string Act() => UserFile.ReadAllText(null!);
 
-        await Assert.That((Func<string>)Act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]
@@ -174,7 +174,7 @@ internal sealed partial class UserFileTests
     {
         static string Act() => UserFile.ReadAllText(string.Empty);
 
-        await Assert.That((Func<string>)Act).Throws<ArgumentException>();
+        await Assert.That(Act).Throws<ArgumentException>();
     }
 
     [Test]
@@ -230,17 +230,17 @@ internal sealed partial class UserFileTests
     [Test]
     public async Task WriteAllText_ReadAllText_RoundTrip()
     {
-        static string Act(string path)
-        {
-            UserFile.WriteAllText(path, "héllo wörld");
-            return UserFile.ReadAllText(path);
-        }
-
         using var file = new TempFile();
 
         var read = Act(file.Path);
 
         await Assert.That(read).IsEqualTo("héllo wörld");
+
+        static string Act(string path)
+        {
+            UserFile.WriteAllText(path, "héllo wörld");
+            return UserFile.ReadAllText(path);
+        }
     }
 
     [Test]

--- a/tests/Buildvana.Core.IO.Tests/UserFileTests.cs
+++ b/tests/Buildvana.Core.IO.Tests/UserFileTests.cs
@@ -142,9 +142,9 @@ internal sealed partial class UserFileTests
     [Test]
     public async Task ReadAllText_WithMalformedPath_Fails()
     {
-        var act = () => UserFile.ReadAllText("a\0b");
+        string Act() => UserFile.ReadAllText("a\0b");
 
-        var exception = await Assert.That(act).Throws<BuildFailedException>();
+        var exception = await Assert.That(Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not read from");
         await Assert.That(exception.InnerException).IsTypeOf<ArgumentException>();
     }
@@ -152,9 +152,9 @@ internal sealed partial class UserFileTests
     [Test]
     public async Task WriteAllText_WithMalformedPath_Fails()
     {
-        var act = () => UserFile.WriteAllText("a\0b", "x");
+        static void Act() => UserFile.WriteAllText("a\0b", "x");
 
-        var exception = await Assert.That(act).Throws<BuildFailedException>();
+        var exception = await Assert.That(Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not write to");
         await Assert.That(exception.InnerException).IsTypeOf<ArgumentException>();
     }
@@ -164,33 +164,33 @@ internal sealed partial class UserFileTests
     [Test]
     public async Task ReadAllText_WithNullPath_ThrowsRaw()
     {
-        var act = () => UserFile.ReadAllText(null!);
+        static string Act() => UserFile.ReadAllText(null!);
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That((Func<string>)Act).Throws<ArgumentNullException>();
     }
 
     [Test]
     public async Task ReadAllText_WithEmptyPath_ThrowsRaw()
     {
-        var act = () => UserFile.ReadAllText(string.Empty);
+        static string Act() => UserFile.ReadAllText(string.Empty);
 
-        await Assert.That(act).Throws<ArgumentException>();
+        await Assert.That((Func<string>)Act).Throws<ArgumentException>();
     }
 
     [Test]
     public async Task WriteAllText_WithNullPath_ThrowsRaw()
     {
-        var act = () => UserFile.WriteAllText(null!, "x");
+        static void Act() => UserFile.WriteAllText(null!, "x");
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]
     public async Task WriteAllText_WithEmptyPath_ThrowsRaw()
     {
-        var act = () => UserFile.WriteAllText(string.Empty, "x");
+        static void Act() => UserFile.WriteAllText(string.Empty, "x");
 
-        await Assert.That(act).Throws<ArgumentException>();
+        await Assert.That(Act).Throws<ArgumentException>();
     }
 
     // The async methods are invoked without await: the guard must throw synchronously,
@@ -198,49 +198,49 @@ internal sealed partial class UserFileTests
     [Test]
     public async Task ReadAllTextAsync_WithNullPath_ThrowsRawAndSynchronously()
     {
-        var act = () => { _ = UserFile.ReadAllTextAsync(null!); };
+        static void Act() => _ = UserFile.ReadAllTextAsync(null!);
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]
     public async Task ReadAllTextAsync_WithEmptyPath_ThrowsRawAndSynchronously()
     {
-        var act = () => { _ = UserFile.ReadAllTextAsync(string.Empty); };
+        static void Act() => _ = UserFile.ReadAllTextAsync(string.Empty);
 
-        await Assert.That(act).Throws<ArgumentException>();
+        await Assert.That(Act).Throws<ArgumentException>();
     }
 
     [Test]
     public async Task WriteAllTextAsync_WithNullPath_ThrowsRawAndSynchronously()
     {
-        var act = () => { _ = UserFile.WriteAllTextAsync(null!, "x"); };
+        static void Act() => _ = UserFile.WriteAllTextAsync(null!, "x");
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]
     public async Task WriteAllTextAsync_WithEmptyPath_ThrowsRawAndSynchronously()
     {
-        var act = () => { _ = UserFile.WriteAllTextAsync(string.Empty, "x"); };
+        static void Act() => _ = UserFile.WriteAllTextAsync(string.Empty, "x");
 
-        await Assert.That(act).Throws<ArgumentException>();
+        await Assert.That(Act).Throws<ArgumentException>();
     }
 
     [Test]
     public async Task WriteAllText_ReadAllText_RoundTrip()
     {
-        using var file = new TempFile();
-
-        var read = Act(file.Path);
-
-        await Assert.That(read).IsEqualTo("héllo wörld");
-
         static string Act(string path)
         {
             UserFile.WriteAllText(path, "héllo wörld");
             return UserFile.ReadAllText(path);
         }
+
+        using var file = new TempFile();
+
+        var read = Act(file.Path);
+
+        await Assert.That(read).IsEqualTo("héllo wörld");
     }
 
     [Test]
@@ -525,17 +525,17 @@ internal sealed partial class UserFileTests
     [Test]
     public async Task Exists_WithNullPath_ThrowsRaw()
     {
-        var act = () => UserFile.Exists(null!);
+        static bool Act() => UserFile.Exists(null!);
 
-        await Assert.That(act).Throws<ArgumentNullException>();
+        await Assert.That(Act).Throws<ArgumentNullException>();
     }
 
     [Test]
     public async Task Exists_WithEmptyPath_ThrowsRaw()
     {
-        var act = () => UserFile.Exists(string.Empty);
+        static bool Act() => UserFile.Exists(string.Empty);
 
-        await Assert.That(act).Throws<ArgumentException>();
+        await Assert.That(Act).Throws<ArgumentException>();
     }
 
     private static async Task AssertDenied(Action act, string expectedMessagePrefix)

--- a/tests/Buildvana.Core.Json.Tests/JsonHelperTests.cs
+++ b/tests/Buildvana.Core.Json.Tests/JsonHelperTests.cs
@@ -18,7 +18,7 @@ internal sealed partial class JsonHelperTests
     {
         static JsonObject Act() => new JsonHelper().LoadObject(DeniedAccessPath);
 
-        var exception = await Assert.That((Func<JsonObject>)Act).Throws<BuildFailedException>();
+        var exception = await Assert.That(Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not read from");
         await Assert.That(exception.InnerException).IsTypeOf<UnauthorizedAccessException>();
     }

--- a/tests/Buildvana.Core.Json.Tests/JsonHelperTests.cs
+++ b/tests/Buildvana.Core.Json.Tests/JsonHelperTests.cs
@@ -16,9 +16,9 @@ internal sealed partial class JsonHelperTests
     [Test]
     public async Task LoadObject_WithDeniedAccess_Fails()
     {
-        var act = () => new JsonHelper().LoadObject(DeniedAccessPath);
+        static JsonObject Act() => new JsonHelper().LoadObject(DeniedAccessPath);
 
-        var exception = await Assert.That(act).Throws<BuildFailedException>();
+        var exception = await Assert.That((Func<JsonObject>)Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not read from");
         await Assert.That(exception.InnerException).IsTypeOf<UnauthorizedAccessException>();
     }
@@ -26,9 +26,9 @@ internal sealed partial class JsonHelperTests
     [Test]
     public async Task SaveObject_WithDeniedAccess_Fails()
     {
-        var act = () => new JsonHelper().SaveObject(new JsonObject(), DeniedAccessPath);
+        static void Act() => new JsonHelper().SaveObject(new JsonObject(), DeniedAccessPath);
 
-        var exception = await Assert.That(act).Throws<BuildFailedException>();
+        var exception = await Assert.That(Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not write to");
         await Assert.That(exception.InnerException).IsTypeOf<UnauthorizedAccessException>();
     }
@@ -36,9 +36,9 @@ internal sealed partial class JsonHelperTests
     [Test]
     public async Task RewriteStringValues_WithDeniedAccess_Fails()
     {
-        var act = () => new JsonHelper().RewriteStringValues(DeniedAccessPath, (_, _) => null);
+        static bool Act() => new JsonHelper().RewriteStringValues(DeniedAccessPath, (_, _) => null);
 
-        var exception = await Assert.That(act).Throws<BuildFailedException>();
+        var exception = await Assert.That(Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not read from");
         await Assert.That(exception.InnerException).IsTypeOf<UnauthorizedAccessException>();
     }
@@ -46,9 +46,9 @@ internal sealed partial class JsonHelperTests
     [Test]
     public async Task InsertProperty_WithDeniedAccess_Fails()
     {
-        var act = () => new JsonHelper().InsertProperty(DeniedAccessPath, [], "a", JsonValue.Create("x"));
+        static bool Act() => new JsonHelper().InsertProperty(DeniedAccessPath, [], "a", JsonValue.Create("x"));
 
-        var exception = await Assert.That(act).Throws<BuildFailedException>();
+        var exception = await Assert.That(Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not read from");
         await Assert.That(exception.InnerException).IsTypeOf<UnauthorizedAccessException>();
     }
@@ -179,9 +179,9 @@ internal sealed partial class JsonHelperTests
         using var file = new TempJsonFile("""{"sdk": {}}""");
         var path = file.Path;
 
-        var act = () => new JsonHelper().InsertProperty(path, ["msbuild-sdks"], "Buildvana.Sdk", JsonValue.Create("x"));
+        bool Act() => new JsonHelper().InsertProperty(path, ["msbuild-sdks"], "Buildvana.Sdk", JsonValue.Create("x"));
 
-        await Assert.That(act).Throws<BuildFailedException>();
+        await Assert.That(Act).Throws<BuildFailedException>();
     }
 
     [Test]
@@ -190,9 +190,9 @@ internal sealed partial class JsonHelperTests
         using var file = new TempJsonFile("""{"msbuild-sdks": [{"a": 1}]}""");
         var path = file.Path;
 
-        var act = () => new JsonHelper().InsertProperty(path, ["msbuild-sdks"], "Buildvana.Sdk", JsonValue.Create("x"));
+        bool Act() => new JsonHelper().InsertProperty(path, ["msbuild-sdks"], "Buildvana.Sdk", JsonValue.Create("x"));
 
-        await Assert.That(act).Throws<BuildFailedException>();
+        await Assert.That(Act).Throws<BuildFailedException>();
     }
 
     [Test]
@@ -201,9 +201,9 @@ internal sealed partial class JsonHelperTests
         using var file = new TempJsonFile("{ not json");
         var path = file.Path;
 
-        var act = () => new JsonHelper().InsertProperty(path, [], "a", JsonValue.Create("x"));
+        bool Act() => new JsonHelper().InsertProperty(path, [], "a", JsonValue.Create("x"));
 
-        await Assert.That(act).Throws<BuildFailedException>();
+        await Assert.That(Act).Throws<BuildFailedException>();
     }
 
     [Test]
@@ -253,7 +253,7 @@ internal sealed partial class JsonHelperTests
     [Test]
     public async Task InsertProperty_PreservesUtf8Bom()
     {
-        var contentBytes = Encoding.UTF8.GetBytes("{\n  \"a\": 1\n}\n");
+        var contentBytes = "{\n  \"a\": 1\n}\n"u8.ToArray();
         using var file = new TempJsonFile([0xEF, 0xBB, 0xBF, .. contentBytes]);
 
         _ = new JsonHelper().InsertProperty(file.Path, [], "b", JsonValue.Create("x"));

--- a/tests/Buildvana.Runtime.Tests/BuildvanaConfigLoadTests.cs
+++ b/tests/Buildvana.Runtime.Tests/BuildvanaConfigLoadTests.cs
@@ -106,11 +106,11 @@ internal sealed class BuildvanaConfigLoadTests
         {
             Write(dir, "buildvana.json", "{}");
             var path = Path.Combine(dir, "buildvana.json");
-            using var locker = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+            await using var locker = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None).ConfigureAwait(false);
 
-            var act = () => BuildvanaConfig.Load(dir);
+            BuildvanaConfig Act() => BuildvanaConfig.Load(dir);
 
-            var exception = await Assert.That(act).Throws<BuildvanaRuntimeException>();
+            var exception = await Assert.That(Act).Throws<BuildvanaRuntimeException>();
             await Assert.That(exception!.Message).Contains("Could not read from");
         }
         finally

--- a/tests/Buildvana.Runtime.Tests/PostReleaseHookContextTests.cs
+++ b/tests/Buildvana.Runtime.Tests/PostReleaseHookContextTests.cs
@@ -77,11 +77,11 @@ internal sealed class PostReleaseHookContextTests
             var path = Path.Combine(dir, WellKnownPaths.GetHookContextFile("release", "post-release"));
             _ = Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             await File.WriteAllTextAsync(path, "{}").ConfigureAwait(false);
-            using var locker = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+            await using var locker = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None).ConfigureAwait(false);
 
-            var act = () => PostReleaseHookContext.Load(dir);
+            PostReleaseHookContext Act() => PostReleaseHookContext.Load(dir);
 
-            var exception = await Assert.That(act).Throws<BuildvanaRuntimeException>();
+            var exception = await Assert.That(Act).Throws<BuildvanaRuntimeException>();
             await Assert.That(exception!.Message).Contains("Could not read from");
         }
         finally

--- a/tests/Buildvana.Tool.Tests/HookRunnerTests.cs
+++ b/tests/Buildvana.Tool.Tests/HookRunnerTests.cs
@@ -134,9 +134,9 @@ internal sealed class HookRunnerTests
         _ = Directory.CreateDirectory(ContextPath(home));
         var context = SampleContext(home);
 
-        var act = () => runner.RunHookAsync("release", "post-release", context);
+        Task<bool> Act() => runner.RunHookAsync("release", "post-release", context);
 
-        var exception = await Assert.That(act).Throws<BuildFailedException>();
+        var exception = await Assert.That(Act).Throws<BuildFailedException>();
         await Assert.That(exception!.Message).Contains("Could not write to");
         await Assert.That(appRunner.Runs.Count).IsEqualTo(0);
     }

--- a/tests/Buildvana.Tool.Tests/SelfVersionServiceTests.cs
+++ b/tests/Buildvana.Tool.Tests/SelfVersionServiceTests.cs
@@ -21,7 +21,7 @@ internal sealed class SelfVersionServiceTests
         WriteGlobalJson(home, pin);
         var service = CreateService(home, ownVersion);
 
-        await Assert.That(() => service.EnsureSdkVersionMatch()).ThrowsNothing();
+        await Assert.That(service.EnsureSdkVersionMatch).ThrowsNothing();
     }
 
     [Test]
@@ -34,7 +34,7 @@ internal sealed class SelfVersionServiceTests
         WriteGlobalJson(home, pin);
         var service = CreateService(home, "2.1.41-preview");
 
-        var exception = await Assert.That(() => service.EnsureSdkVersionMatch()).Throws<BuildFailedException>();
+        var exception = await Assert.That(service.EnsureSdkVersionMatch).Throws<BuildFailedException>();
 
         await Assert.That(exception!.Message).Contains(pin);
         await Assert.That(exception.Message).Contains("2.1.41-preview");
@@ -47,7 +47,7 @@ internal sealed class SelfVersionServiceTests
         using var home = new TempHome();
         var service = CreateService(home, "2.1.41-preview");
 
-        var exception = await Assert.That(() => service.EnsureSdkVersionMatch()).Throws<BuildFailedException>();
+        var exception = await Assert.That(service.EnsureSdkVersionMatch).Throws<BuildFailedException>();
 
         await Assert.That(exception!.Message).Contains("global.json");
         await Assert.That(exception.Message).Contains("bv update");
@@ -60,7 +60,7 @@ internal sealed class SelfVersionServiceTests
         home.WriteFile("global.json", """{ "sdk": { "version": "10.0.302" } }""");
         var service = CreateService(home, "2.1.41-preview");
 
-        var exception = await Assert.That(() => service.EnsureSdkVersionMatch()).Throws<BuildFailedException>();
+        var exception = await Assert.That(service.EnsureSdkVersionMatch).Throws<BuildFailedException>();
 
         await Assert.That(exception!.Message).Contains("msbuild-sdks");
     }
@@ -72,7 +72,7 @@ internal sealed class SelfVersionServiceTests
         home.WriteFile("global.json", """{ "msbuild-sdks": { "Microsoft.Build.NoTargets": "3.7.134" } }""");
         var service = CreateService(home, "2.1.41-preview");
 
-        var exception = await Assert.That(() => service.EnsureSdkVersionMatch()).Throws<BuildFailedException>();
+        var exception = await Assert.That(service.EnsureSdkVersionMatch).Throws<BuildFailedException>();
 
         await Assert.That(exception!.Message).Contains("Buildvana.Sdk");
     }
@@ -84,7 +84,7 @@ internal sealed class SelfVersionServiceTests
         WriteGlobalJson(home, "not-a-version");
         var service = CreateService(home, "2.1.41-preview");
 
-        var exception = await Assert.That(() => service.EnsureSdkVersionMatch()).Throws<BuildFailedException>();
+        var exception = await Assert.That(service.EnsureSdkVersionMatch).Throws<BuildFailedException>();
 
         await Assert.That(exception!.Message).Contains("not-a-version");
     }

--- a/tests/Common.targets
+++ b/tests/Common.targets
@@ -13,12 +13,6 @@
     <!-- No need for public API analyzers -->
     <UsePublicApiAnalyzers>false</UsePublicApiAnalyzers>
 
-    <!-- Disable some warnings that have no sense in test projects -->
-    <NoWarn>$(NoWarn);CA1050</NoWarn> <!-- Declare types in namespaces -->
-    <NoWarn>$(NoWarn);CA1707</NoWarn> <!-- Identifiers should not contain underscores -->
-    <NoWarn>$(NoWarn);IDE0058</NoWarn> <!-- Expression value is never used -->
-    <NoWarn>$(NoWarn);SA1600</NoWarn> <!-- Elements should be documented - test code is self-describing -->
-
   </PropertyGroup>
 
   <!-- Hide test result files in Visual Studio -->


### PR DESCRIPTION
## Proposed changes

Following a review of ReSharper's hint-level output, this PR turns the consistently valuable suggestions into enforced rules, codifies the underlying style preference (pattern matching) in the C# style guide, and cleans up everything the new severities flagged. The solution now analyzes clean at _all_ severity levels, hints included.

- **Style guide**: new "Pattern matching" section — prefer patterns over equivalent comparison/type-check/cast chains, with the `Equals`-vs-`==` caveat spelled out.
- **Promotions to warning** (ReSharper keys in `.editorconfig`, plus Roslyn twins IDE0011, IDE0039, IDE0063, IDE0200 where they exist): merge into pattern, use pattern matching, merge cast with type check, `await using`, u8 string literals, `GetValueOrDefault` over `TryGetValue` chains, method groups over closures, local functions over lambdas, init-only properties, braces, simple `using` statements.
- **Test-scoped relaxations** (`tests/.editorconfig`): local-function placement/separation rules, member-can-be-made-static (TUnit test methods must be public instance methods), target-typed `new`.
- **Single source of truth**: test analyzer exceptions moved from `Common.targets` `NoWarn` items to `tests/.editorconfig`, where compiler, IDE, and `inspectcode` all read them.
- **MSBuild task exemption** (`src/Buildvana.Sdk.Tasks/.editorconfig`): get-only/init-only property suggestions are meaningless for engine-set task properties.
- **Resulting code fixes**: test lambdas converted to local functions (via `dotnet format`), fake callback hooks made init-only, one list pattern, plus assorted `await using`/u8/method-group fixes.

No changelog entry: nothing here is public-facing — packages' behavior and public API are unchanged.

Verified: `dotnet bv pack` green (all three packages produced), `inspectcode --severity=WARNING` reports zero results, and a full no-threshold ReSharper pass reports zero diagnostics down to hint level.

### Checklist of related issues / discussions

- [ ] Fixes #
- [ ] Partially fixes #
- [ ] Related discussion(s): #

_No corresponding issue — analyzer configuration change grown out of an interactive review session._

## Types of changes

This pull request introduces the following types of changes:

- [ ] Bug fix
- [ ] New feature
- [ ] Test addition / update (no changes to non-test code)
- [x] Refactor (no changes in public API syntax or semantics)
- [ ] Performance improvement (no changes in public API syntax or semantics)
- [ ] Documentation (`docs` directory) update
- [ ] Dependency addition / update
- [ ] Changes to the build scripts
- [ ] Changes to CI (workflows, bot / app configurations)
- [ ] Changes to repository files (`.gitattributes`, `.gitignore`)
- [x] Other

_Other: analyzer severity configuration (`.editorconfig` files, `tests/Common.targets`) and C# style guide update._

### Breaking changes

This pull request introduces breaking changes:

- [ ] Yes
- [x] No

## Checklist

- **For all types of changes:**
  - [x] I have read the [Code of Conduct](https://github.com/Tenacom/.github/blob/main/CODE_OF_CONDUCT.md) and agree to be bound by it
  - [x] I have read the [Contributor Guide](https://github.com/Tenacom/.github/blob/main/CONTRIBUTING.md) and agree to follow it
- **For code changes only:**
  - [x] The project builds on my machine, via the provided build script, _with zero warnings_
  - [ ] I have added tests that prove my feature works / my fix is effective
  - [ ] I have added / modified XML documentation according to changes in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)