### PR TITLE
Stop reporting the version from a constructor

### DIFF
--- a/src/Buildvana.Core.Versioning/VersionCalculator.cs
+++ b/src/Buildvana.Core.Versioning/VersionCalculator.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Buildvana.Core.HomeDirectory;
+using CommunityToolkit.Diagnostics;
+using NuGet.Versioning;
+
+namespace Buildvana.Core.Versioning;
+
+/// <summary>
+/// Computes the version being built from the repository's version file, Git height, and versioning settings.
+/// </summary>
+/// <remarks>
+/// <para>The version file (<see cref="VersionFile.FileName"/>, in the home directory) holds a
+/// <c>MAJOR.MINOR[-[tag]]</c> specification; the patch number is the Git height of the version line
+/// (see <see cref="GitHeightCalculator"/>).</para>
+/// <para>An instance carries no computed state: it reads the repository afresh on every
+/// <see cref="Calculate"/> call, so a consumer that changes what the version depends on — by committing,
+/// or by rewriting the version file — calls it again for a <see cref="VersionInfo"/> matching the new state.</para>
+/// </remarks>
+public sealed class VersionCalculator
+{
+    private readonly IHomeDirectoryProvider _home;
+    private readonly VersioningSettings _settings;
+    private readonly GitHeightCalculator _heightCalculator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VersionCalculator"/> class.
+    /// </summary>
+    /// <param name="home">The home directory provider used to locate the version file and the Git repository.</param>
+    /// <param name="settings">The versioning settings.</param>
+    /// <param name="heightCalculator">The calculator providing the Git height of the version line.</param>
+    public VersionCalculator(IHomeDirectoryProvider home, VersioningSettings settings, GitHeightCalculator heightCalculator)
+    {
+        Guard.IsNotNull(home);
+        Guard.IsNotNull(settings);
+        Guard.IsNotNull(heightCalculator);
+        _home = home;
+        _settings = settings;
+        _heightCalculator = heightCalculator;
+    }
+
+    /// <summary>
+    /// Computes the version being built, as the repository stands now.
+    /// </summary>
+    /// <returns>A newly-created <see cref="VersionInfo"/>.</returns>
+    /// <exception cref="BuildFailedException">
+    /// <para>The version file is absent or does not contain a valid version specification.</para>
+    /// <para>The version is a prerelease, but <see cref="VersioningSettings.PrereleaseTag"/> is unset or invalid.</para>
+    /// <para>There is no Git repository in the home directory, or a <c>release.branches</c> pattern is invalid.</para>
+    /// </exception>
+    public VersionInfo Calculate()
+    {
+        var spec = VersionFile.Load(_home).Spec;
+        var prereleaseTag = spec.Prerelease ? GetPrereleaseTag(_settings) : null;
+        var facts = _heightCalculator.Calculate(_home.HomeDirectory, spec);
+        return new(
+            spec,
+            facts.Height,
+            facts.CommitId,
+            _settings.IsPublicReleaseBranch(facts.BranchName),
+            prereleaseTag,
+            _settings.AssemblyVersionPrecision);
+    }
+
+    private static string GetPrereleaseTag(VersioningSettings settings)
+    {
+        var tag = settings.PrereleaseTag;
+        BuildFailedException.ThrowIf(
+            string.IsNullOrEmpty(tag),
+            $"{VersionFile.FileName} specifies a prerelease version, but versioning.prereleaseTag is not set in the configuration file.");
+        var isValid = SemanticVersion.TryParse(FormattableString.Invariant($"0.0.0-{tag}"), out _);
+        BuildFailedException.ThrowIfNot(
+            isValid,
+            $"'{tag}' (versioning.prereleaseTag in the configuration file) is not a valid prerelease tag.");
+        return tag;
+    }
+}

--- a/src/Buildvana.Core.Versioning/VersionInfo.cs
+++ b/src/Buildvana.Core.Versioning/VersionInfo.cs
@@ -33,7 +33,7 @@ public sealed class VersionInfo
     /// <param name="prereleaseTag">The prerelease tag to apply, or <see langword="null"/> if the version
     /// is not a prerelease.</param>
     /// <param name="assemblyVersionPrecision">The precision to compute <see cref="AssemblyVersion"/> at.</param>
-    public VersionInfo(
+    internal VersionInfo(
         VersionSpec spec,
         int height,
         string? commitId,

--- a/src/Buildvana.Core.Versioning/VersionInfo.cs
+++ b/src/Buildvana.Core.Versioning/VersionInfo.cs
@@ -50,7 +50,7 @@ public sealed class VersionInfo
         SemVer = prereleaseTag is null ? SimpleVersion : $"{SimpleVersion}-{prereleaseTag}";
         AssemblyVersion = ComputeAssemblyVersion(spec, height, assemblyVersionPrecision);
         FileVersion = FormattableString.Invariant($"{SimpleVersion}.0");
-        InformationalVersion = ComputeInformationalVersion(SemVer, spec.Prerelease, isPublicRelease, commitId);
+        InformationalVersion = ComputeInformationalVersion(SemVer, prereleaseTag is not null, isPublicRelease, commitId);
     }
 
     /// <summary>
@@ -116,14 +116,22 @@ public sealed class VersionInfo
         return FormattableString.Invariant($"{spec.Major}.{minor}.{build}.0");
     }
 
-    private static string ComputeInformationalVersion(string semVer, bool prerelease, bool isPublicRelease, string? commitId)
+    // Which separator to use is decided by the string being appended to, not by the version spec: a semantic
+    // version that already carries a prerelease part takes the commit ID as a further dot-separated identifier,
+    // while one that carries none takes it as the prerelease part itself. The prerelease tag is what puts that
+    // part there, so reading the answer off the tag keeps the two in step whatever else it is paired with.
+    private static string ComputeInformationalVersion(
+        string semVer,
+        bool hasPrereleaseTag,
+        bool isPublicRelease,
+        string? commitId)
     {
         if (isPublicRelease || commitId is null)
         {
             return semVer;
         }
 
-        var separator = prerelease ? '.' : '-';
+        var separator = hasPrereleaseTag ? '.' : '-';
         return FormattableString.Invariant($"{semVer}{separator}g{commitId[..ShortCommitIdLength]}");
     }
 }

--- a/src/Buildvana.Core.Versioning/VersionInfo.cs
+++ b/src/Buildvana.Core.Versioning/VersionInfo.cs
@@ -2,64 +2,55 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using Buildvana.Core.ConsoleOutput;
-using Buildvana.Core.HomeDirectory;
 using Buildvana.Runtime;
 using CommunityToolkit.Diagnostics;
-using NuGet.Versioning;
 
 namespace Buildvana.Core.Versioning;
 
 /// <summary>
-/// Computes the version being built from the repository's version file, Git height, and versioning settings,
-/// and exposes it in the string forms needed by builds and releases.
+/// The version being built: the specification it comes from, the repository facts it was computed from,
+/// and the version strings a build and a release need.
 /// </summary>
 /// <remarks>
-/// <para>The version file (<see cref="VersionFile.FileName"/>, in the home directory) holds a
-/// <c>MAJOR.MINOR[-[tag]]</c> specification; the patch number is the Git height of the version line
-/// (see <see cref="GitHeightCalculator"/>). All values are computed once, on construction.</para>
+/// <para>An instance is a snapshot of the repository as it stood when <see cref="VersionCalculator.Calculate"/>
+/// produced it. Anything that changes the Git height or the version file makes it stale, so a consumer that
+/// outlives such a change calculates again instead of holding on to one.</para>
 /// </remarks>
-public sealed class VersioningService
+public sealed class VersionInfo
 {
     private const int ShortCommitIdLength = 10;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="VersioningService"/> class, computing the version being built.
+    /// Initializes a new instance of the <see cref="VersionInfo"/> class, deriving every version string
+    /// from the version specification, the repository facts, and the versioning settings.
     /// </summary>
-    /// <param name="reporter">The reporter used to log the computed version.</param>
-    /// <param name="home">The home directory provider used to locate the version file and the Git repository.</param>
-    /// <param name="settings">The versioning settings.</param>
-    /// <param name="heightCalculator">The calculator providing the Git height of the version line.</param>
-    /// <exception cref="BuildFailedException">
-    /// <para>The version file is absent or does not contain a valid version specification.</para>
-    /// <para>The version is a prerelease, but <see cref="VersioningSettings.PrereleaseTag"/> is unset or invalid.</para>
-    /// <para>There is no Git repository in the home directory, or a <c>release.branches</c> pattern is invalid.</para>
-    /// </exception>
-    public VersioningService(
-        IReporter reporter,
-        IHomeDirectoryProvider home,
-        VersioningSettings settings,
-        GitHeightCalculator heightCalculator)
+    /// <param name="spec">The version specification read from the version file.</param>
+    /// <param name="height">The Git height of the version line, used as the patch number.</param>
+    /// <param name="commitId">The SHA of the current <c>HEAD</c> commit, or <see langword="null"/> if the
+    /// repository has no commits.</param>
+    /// <param name="isPublicRelease"><see langword="true"/> if the current branch produces public releases;
+    /// otherwise, <see langword="false"/>.</param>
+    /// <param name="prereleaseTag">The prerelease tag to apply, or <see langword="null"/> if the version
+    /// is not a prerelease.</param>
+    /// <param name="assemblyVersionPrecision">The precision to compute <see cref="AssemblyVersion"/> at.</param>
+    public VersionInfo(
+        VersionSpec spec,
+        int height,
+        string? commitId,
+        bool isPublicRelease,
+        string? prereleaseTag,
+        AssemblyVersionPrecision assemblyVersionPrecision)
     {
-        Guard.IsNotNull(reporter);
-        Guard.IsNotNull(home);
-        Guard.IsNotNull(settings);
-        Guard.IsNotNull(heightCalculator);
-
-        var homeDirectory = home.HomeDirectory;
-        Spec = VersionFile.Load(home).Spec;
-        var prereleaseTag = Spec.Prerelease ? GetPrereleaseTag(settings) : null;
-        var facts = heightCalculator.Calculate(homeDirectory, Spec);
-        Height = facts.Height;
-        CommitId = facts.CommitId;
-        IsPublicRelease = settings.IsPublicReleaseBranch(facts.BranchName);
-        SimpleVersion = FormattableString.Invariant($"{Spec.Major}.{Spec.Minor}.{Height}");
+        Guard.IsNotNull(spec);
+        Spec = spec;
+        Height = height;
+        CommitId = commitId;
+        IsPublicRelease = isPublicRelease;
+        SimpleVersion = FormattableString.Invariant($"{spec.Major}.{spec.Minor}.{height}");
         SemVer = prereleaseTag is null ? SimpleVersion : $"{SimpleVersion}-{prereleaseTag}";
-        AssemblyVersion = ComputeAssemblyVersion(Spec, Height, settings.AssemblyVersionPrecision);
+        AssemblyVersion = ComputeAssemblyVersion(spec, height, assemblyVersionPrecision);
         FileVersion = FormattableString.Invariant($"{SimpleVersion}.0");
-        InformationalVersion = ComputeInformationalVersion(SemVer, Spec.Prerelease, IsPublicRelease, CommitId);
-        var publicity = IsPublicRelease ? "public release" : "not a public release";
-        reporter.Notice(FormattableString.Invariant($"Version {SemVer} (height {Height}, {publicity})"));
+        InformationalVersion = ComputeInformationalVersion(SemVer, spec.Prerelease, isPublicRelease, commitId);
     }
 
     /// <summary>
@@ -117,19 +108,6 @@ public sealed class VersioningService
     /// appended to the prerelease part when the build is not a public release.
     /// </summary>
     public string InformationalVersion { get; }
-
-    private static string GetPrereleaseTag(VersioningSettings settings)
-    {
-        var tag = settings.PrereleaseTag;
-        BuildFailedException.ThrowIf(
-            string.IsNullOrEmpty(tag),
-            $"{VersionFile.FileName} specifies a prerelease version, but versioning.prereleaseTag is not set in the configuration file.");
-        var isValid = SemanticVersion.TryParse(FormattableString.Invariant($"0.0.0-{tag}"), out _);
-        BuildFailedException.ThrowIfNot(
-            isValid,
-            $"'{tag}' (versioning.prereleaseTag in the configuration file) is not a valid prerelease tag.");
-        return tag;
-    }
 
     private static string ComputeAssemblyVersion(VersionSpec spec, int height, AssemblyVersionPrecision precision)
     {

--- a/src/Buildvana.Core.Versioning/VersionInfo.cs
+++ b/src/Buildvana.Core.Versioning/VersionInfo.cs
@@ -104,8 +104,9 @@ public sealed class VersionInfo
     public string FileVersion { get; }
 
     /// <summary>
-    /// Gets the informational version: <see cref="SemVer"/>, plus a <c>g</c>-prefixed short commit ID
-    /// appended to the prerelease part when the build is not a public release.
+    /// Gets the informational version: <see cref="SemVer"/>, plus a <c>g</c>-prefixed short commit ID that
+    /// joins the prerelease part, or becomes it when the version has none. The commit ID is left out of a
+    /// public release, and where the repository has no commit to name.
     /// </summary>
     public string InformationalVersion { get; }
 

--- a/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion-caching.cs
+++ b/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion-caching.cs
@@ -17,23 +17,23 @@ partial class ComputeVersion
 {
     private static readonly ConcurrentDictionary<string, CachedVersion> Cache = new(StringComparer.Ordinal);
 
-    private static CachedVersion GetOrComputeVersion(string homeDirectory, IReporter reporter)
+    private static VersionInfo GetOrComputeVersion(string homeDirectory, IReporter reporter)
     {
         homeDirectory = Path.GetFullPath(homeDirectory);
         var fingerprint = ComputeFingerprint(homeDirectory);
         if (fingerprint is null)
         {
-            return ComputeCore(homeDirectory, reporter, null);
+            return ComputeCore(homeDirectory, reporter, null).Version;
         }
 
         if (Cache.TryGetValue(homeDirectory, out var cached) && cached.Fingerprint == fingerprint)
         {
-            return cached;
+            return cached.Version;
         }
 
         var computed = ComputeCore(homeDirectory, reporter, fingerprint);
         Cache[homeDirectory] = computed;
-        return computed;
+        return computed.Version;
     }
 
     // The computed version is reported at detail level, so it stays out of the way at the verbosities a

--- a/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion-caching.cs
+++ b/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion-caching.cs
@@ -36,30 +36,28 @@ partial class ComputeVersion
         return computed;
     }
 
+    // The computed version is reported at detail level, so it stays out of the way at the verbosities a
+    // build is normally run at. There is nothing here for a user to act upon: the version reaches them
+    // through the artifacts it stamps, and this line is emitted once per cache miss, i.e. once per process
+    // taking part in the build - a count that reflects MSBuild's node topology rather than anything about
+    // the repository. What it is good for is following a build closely enough to see when, and how often,
+    // the version is actually computed.
     private static CachedVersion ComputeCore(string homeDirectory, IReporter reporter, string? fingerprint)
     {
         var home = new FixedHomeDirectoryProvider(homeDirectory);
-        var service = new VersioningService(
-            reporter,
+        var calculator = new VersionCalculator(
             home,
             new VersioningSettings(new BuildvanaConfigProvider(home).Config),
             new GitHeightCalculator(VersionFile.FileName));
-        return new CachedVersion(
-            fingerprint,
-            service.SimpleVersion,
-            service.SemVer,
-            service.AssemblyVersion,
-            service.FileVersion,
-            service.InformationalVersion,
-            service.IsPublicRelease,
-            service.IsPrerelease,
-            service.CommitId ?? string.Empty,
-            service.Height);
+        var version = calculator.Calculate();
+        var publicity = version.IsPublicRelease ? "public release" : "not a public release";
+        reporter.Detail(FormattableString.Invariant($"Computed version {version.SemVer} (height {version.Height}, {publicity})."));
+        return new CachedVersion(fingerprint, version);
     }
 
     // The fingerprint captures everything the computed version depends on: the working-tree VERSION file,
     // the configuration file, and the repository state (the height walk only sees commits reachable from HEAD).
-    // A null fingerprint disables caching, letting VersioningService surface the proper error.
+    // A null fingerprint disables caching, letting VersionCalculator surface the proper error.
     private static string? ComputeFingerprint(string homeDirectory)
     {
         try

--- a/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion.CachedVersion.cs
+++ b/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion.CachedVersion.cs
@@ -1,23 +1,15 @@
 ﻿// Copyright (C) Tenacom and Contributors. Licensed under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Buildvana.Core.Versioning;
+
 namespace Buildvana.Sdk.Tasks;
 
 partial class ComputeVersion
 {
     /// <summary>
-    /// The computed version values for a home directory, together with the repository-state fingerprint
-    /// they were computed from (<see langword="null"/> if the state could not be fingerprinted).
+    /// The version computed for a home directory, together with the repository-state fingerprint it was
+    /// computed from (<see langword="null"/> if the state could not be fingerprinted).
     /// </summary>
-    private sealed record CachedVersion(
-        string? Fingerprint,
-        string SimpleVersion,
-        string SemVer,
-        string AssemblyVersion,
-        string FileVersion,
-        string InformationalVersion,
-        bool IsPublicRelease,
-        bool IsPrerelease,
-        string CommitId,
-        int Height);
+    private sealed record CachedVersion(string? Fingerprint, VersionInfo Version);
 }

--- a/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion.cs
+++ b/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion.cs
@@ -52,7 +52,7 @@ public sealed partial class ComputeVersion : BuildvanaSdkTask
             string.IsNullOrEmpty(HomeDirectory),
             string.Format(CultureInfo.InvariantCulture, Strings.MissingParameterFmt, nameof(HomeDirectory)));
 
-        var version = GetOrComputeVersion(HomeDirectory, Reporter).Version;
+        var version = GetOrComputeVersion(HomeDirectory, Reporter);
         SimpleVersion = version.SimpleVersion;
         SemVer = version.SemVer;
         AssemblyVersion = version.AssemblyVersion;

--- a/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion.cs
+++ b/src/Buildvana.Sdk.Tasks/Tasks/ComputeVersion.cs
@@ -52,7 +52,7 @@ public sealed partial class ComputeVersion : BuildvanaSdkTask
             string.IsNullOrEmpty(HomeDirectory),
             string.Format(CultureInfo.InvariantCulture, Strings.MissingParameterFmt, nameof(HomeDirectory)));
 
-        var version = GetOrComputeVersion(HomeDirectory, Reporter);
+        var version = GetOrComputeVersion(HomeDirectory, Reporter).Version;
         SimpleVersion = version.SimpleVersion;
         SemVer = version.SemVer;
         AssemblyVersion = version.AssemblyVersion;
@@ -60,7 +60,7 @@ public sealed partial class ComputeVersion : BuildvanaSdkTask
         InformationalVersion = version.InformationalVersion;
         IsPublicRelease = version.IsPublicRelease;
         IsPrerelease = version.IsPrerelease;
-        CommitId = version.CommitId;
+        CommitId = version.CommitId ?? string.Empty;
         Height = version.Height;
         return Undefined.Value;
     }

--- a/src/Buildvana.Tool/Services/Versioning/VersionService.cs
+++ b/src/Buildvana.Tool/Services/Versioning/VersionService.cs
@@ -13,19 +13,17 @@ using NuGet.Versioning;
 namespace Buildvana.Tool.Services.Versioning;
 
 /// <summary>
-/// Exposes the version being built, computed by <see cref="VersioningService"/>, alongside
+/// Exposes the version being built, computed by a <see cref="VersionCalculator"/>, alongside
 /// release-flow version policy: consistency checks against published versions and computation
 /// of the version specification change to apply upon release.
 /// </summary>
 internal sealed partial class VersionService
 {
     private readonly IReporter _reporter;
-    private readonly IHomeDirectoryProvider _home;
-    private readonly VersioningSettings _settings;
-    private readonly GitHeightCalculator _heightCalculator;
+    private readonly VersionCalculator _calculator;
     private readonly PublicApiFilesService _publicApiFiles;
 
-    private VersioningService _current;
+    private VersionInfo _current;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="VersionService"/> class.
@@ -43,11 +41,9 @@ internal sealed partial class VersionService
         Guard.IsNotNull(git);
         Guard.IsNotNull(publicApiFiles);
         _reporter = reporter;
-        _home = home;
-        _settings = settings;
         _publicApiFiles = publicApiFiles;
-        _heightCalculator = new(VersionFile.FileName);
-        _current = new(reporter, home, settings, _heightCalculator);
+        _calculator = new(home, settings, new GitHeightCalculator(VersionFile.FileName));
+        _current = _calculator.Calculate();
         Current = SemanticVersion.Parse(_current.SemVer);
         (Latest, LatestStable) = git.GetLatestVersions();
     }
@@ -205,7 +201,7 @@ internal sealed partial class VersionService
     /// </summary>
     public void Update()
     {
-        _current = new(_reporter, _home, _settings, _heightCalculator);
+        _current = _calculator.Calculate();
         Current = SemanticVersion.Parse(_current.SemVer);
     }
 }

--- a/src/Buildvana.Tool/Subcommands/ReleaseCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/ReleaseCommand.cs
@@ -198,6 +198,11 @@ internal sealed class ReleaseCommand(
             // Time for a final consistency check.
             version.EnsureConsistency(true);
 
+            // The version is now final: everything that could still move it (the version spec change, the
+            // changelog update, the release commit) has happened, and the artifacts are built from here on.
+            // This is the one place where stating it is a record of a decision rather than a guess.
+            reporter.Notice($"Releasing version {version.CurrentStr}.");
+
             // Ensure that the release tag doesn't already exist.
             // This assumes that full repo history has been checked out;
             // however, that is already a prerequisite for computing the Git height.

--- a/src/Buildvana.Tool/Subcommands/ReleaseCommand.cs
+++ b/src/Buildvana.Tool/Subcommands/ReleaseCommand.cs
@@ -198,15 +198,16 @@ internal sealed class ReleaseCommand(
             // Time for a final consistency check.
             version.EnsureConsistency(true);
 
-            // The version is now final: everything that could still move it (the version spec change, the
-            // changelog update, the release commit) has happened, and the artifacts are built from here on.
-            // This is the one place where stating it is a record of a decision rather than a guess.
-            reporter.Notice($"Releasing version {version.CurrentStr}.");
-
             // Ensure that the release tag doesn't already exist.
             // This assumes that full repo history has been checked out;
             // however, that is already a prerequisite for computing the Git height.
             BuildFailedException.ThrowIf(git.TagExists(version.CurrentStr), $"Tag '{version.CurrentStr}' already exists in repository.");
+
+            // The version is now final: everything that could still move it (the version spec change, the
+            // changelog update, the release commit) has happened, the tag check above is the last thing that
+            // can refuse this particular version, and the artifacts are built from here on. This is the one
+            // place where stating the version is a record of a decision rather than a guess.
+            reporter.Notice($"Releasing version {version.CurrentStr}.");
 
             // Artifact pass (Restore→Pack, no Clean): rebuild against the resolved version and make artifacts.
             await pipeline.RunRangeAsync(BuildStep.Restore, BuildStep.Pack, configuration, cancellationToken).ConfigureAwait(false);

--- a/tests/Buildvana.Core.Versioning.Tests/VersionCalculatorTests.cs
+++ b/tests/Buildvana.Core.Versioning.Tests/VersionCalculatorTests.cs
@@ -2,60 +2,59 @@
 // See the LICENSE file in the project root for full license information.
 
 using Buildvana.Core;
-using Buildvana.Core.ConsoleOutput;
 using Buildvana.Core.HomeDirectory;
 using Buildvana.Core.Testing;
 using Buildvana.Core.Versioning;
 using Buildvana.Runtime;
 
-internal sealed class VersioningServiceTests
+internal sealed class VersionCalculatorTests
 {
     [Test]
-    public async Task Constructor_MissingVersionFile_Throws()
+    public async Task Calculate_MissingVersionFile_Throws()
     {
         using var repo = new TempGitRepo();
         repo.CommitAll();
-        var exception = CatchCreate(repo, new BuildvanaConfig());
+        var exception = CatchCalculate(repo, new BuildvanaConfig());
         await Assert.That(exception).IsNotNull();
         await Assert.That(exception!.Message).Contains("VERSION");
     }
 
     [Test]
-    public async Task Constructor_MalformedVersionFile_Throws()
+    public async Task Calculate_MalformedVersionFile_Throws()
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "banana\n");
         repo.CommitAll();
-        var exception = CatchCreate(repo, new BuildvanaConfig());
+        var exception = CatchCalculate(repo, new BuildvanaConfig());
         await Assert.That(exception).IsNotNull();
         await Assert.That(exception!.Message).Contains("banana");
     }
 
     [Test]
-    public async Task Constructor_PrereleaseWithoutTag_Throws()
+    public async Task Calculate_PrereleaseWithoutTag_Throws()
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "1.0-\n");
         repo.CommitAll();
-        var exception = CatchCreate(repo, new BuildvanaConfig());
+        var exception = CatchCalculate(repo, new BuildvanaConfig());
         await Assert.That(exception).IsNotNull();
         await Assert.That(exception!.Message).Contains("versioning.prereleaseTag");
     }
 
     [Test]
-    public async Task Constructor_InvalidPrereleaseTag_Throws()
+    public async Task Calculate_InvalidPrereleaseTag_Throws()
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "1.0-\n");
         repo.CommitAll();
         var config = new BuildvanaConfig { Versioning = new VersioningConfig { PrereleaseTag = "not valid" } };
-        var exception = CatchCreate(repo, config);
+        var exception = CatchCalculate(repo, config);
         await Assert.That(exception).IsNotNull();
         await Assert.That(exception!.Message).Contains("not valid");
     }
 
     [Test]
-    public async Task Constructor_StablePublicRelease_ComputesVersionStrings()
+    public async Task Calculate_StablePublicRelease_ComputesVersionStrings()
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "2.3\n");
@@ -63,19 +62,19 @@ internal sealed class VersioningServiceTests
         repo.CheckoutNewBranch("rel");
         repo.CommitAll();
         var config = new BuildvanaConfig { Release = new ReleaseConfig { Branches = ["^rel$"] } };
-        var service = CreateService(repo, config);
-        await Assert.That(service.Spec).IsEqualTo(new VersionSpec(2, 3, false));
-        await Assert.That(service.Height).IsEqualTo(2);
-        await Assert.That(service.IsPublicRelease).IsTrue();
-        await Assert.That(service.IsPrerelease).IsFalse();
-        await Assert.That(service.SimpleVersion).IsEqualTo("2.3.2");
-        await Assert.That(service.SemVer).IsEqualTo("2.3.2");
-        await Assert.That(service.InformationalVersion).IsEqualTo("2.3.2");
-        await Assert.That(service.CommitId).IsEqualTo(repo.HeadSha);
+        var version = CalculateVersion(repo, config);
+        await Assert.That(version.Spec).IsEqualTo(new VersionSpec(2, 3, false));
+        await Assert.That(version.Height).IsEqualTo(2);
+        await Assert.That(version.IsPublicRelease).IsTrue();
+        await Assert.That(version.IsPrerelease).IsFalse();
+        await Assert.That(version.SimpleVersion).IsEqualTo("2.3.2");
+        await Assert.That(version.SemVer).IsEqualTo("2.3.2");
+        await Assert.That(version.InformationalVersion).IsEqualTo("2.3.2");
+        await Assert.That(version.CommitId).IsEqualTo(repo.HeadSha);
     }
 
     [Test]
-    public async Task Constructor_PrereleasePublicRelease_AppendsTagOnly()
+    public async Task Calculate_PrereleasePublicRelease_AppendsTagOnly()
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "2.3-x\n");
@@ -86,82 +85,81 @@ internal sealed class VersioningServiceTests
             Release = new ReleaseConfig { Branches = ["^rel$"] },
             Versioning = new VersioningConfig { PrereleaseTag = "preview" },
         };
-        var service = CreateService(repo, config);
-        await Assert.That(service.IsPrerelease).IsTrue();
-        await Assert.That(service.SemVer).IsEqualTo("2.3.1-preview");
-        await Assert.That(service.InformationalVersion).IsEqualTo("2.3.1-preview");
+        var version = CalculateVersion(repo, config);
+        await Assert.That(version.IsPrerelease).IsTrue();
+        await Assert.That(version.SemVer).IsEqualTo("2.3.1-preview");
+        await Assert.That(version.InformationalVersion).IsEqualTo("2.3.1-preview");
     }
 
     [Test]
-    public async Task Constructor_PrereleaseNonPublic_AppendsCommitIdToInformationalVersion()
+    public async Task Calculate_PrereleaseNonPublic_AppendsCommitIdToInformationalVersion()
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "2.3-x\n");
         repo.CommitAll();
         var config = new BuildvanaConfig { Versioning = new VersioningConfig { PrereleaseTag = "preview" } };
-        var service = CreateService(repo, config);
-        await Assert.That(service.IsPublicRelease).IsFalse();
-        await Assert.That(service.SemVer).IsEqualTo("2.3.1-preview");
-        await Assert.That(service.InformationalVersion).IsEqualTo($"2.3.1-preview.g{repo.HeadSha[..10]}");
+        var version = CalculateVersion(repo, config);
+        await Assert.That(version.IsPublicRelease).IsFalse();
+        await Assert.That(version.SemVer).IsEqualTo("2.3.1-preview");
+        await Assert.That(version.InformationalVersion).IsEqualTo($"2.3.1-preview.g{repo.HeadSha[..10]}");
     }
 
     [Test]
-    public async Task Constructor_StableNonPublic_AppendsCommitIdAsPrerelease()
+    public async Task Calculate_StableNonPublic_AppendsCommitIdAsPrerelease()
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "2.3\n");
         repo.CommitAll();
-        var service = CreateService(repo, new BuildvanaConfig());
-        await Assert.That(service.SemVer).IsEqualTo("2.3.1");
-        await Assert.That(service.InformationalVersion).IsEqualTo($"2.3.1-g{repo.HeadSha[..10]}");
+        var version = CalculateVersion(repo, new BuildvanaConfig());
+        await Assert.That(version.SemVer).IsEqualTo("2.3.1");
+        await Assert.That(version.InformationalVersion).IsEqualTo($"2.3.1-g{repo.HeadSha[..10]}");
     }
 
     [Test]
     [Arguments(AssemblyVersionPrecision.Major, "2.0.0.0")]
     [Arguments(AssemblyVersionPrecision.Minor, "2.3.0.0")]
     [Arguments(AssemblyVersionPrecision.Build, "2.3.1.0")]
-    public async Task Constructor_AssemblyVersionHonorsPrecision(AssemblyVersionPrecision precision, string expected)
+    public async Task Calculate_AssemblyVersionHonorsPrecision(AssemblyVersionPrecision precision, string expected)
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "2.3\n");
         repo.CommitAll();
         var config = new BuildvanaConfig { Versioning = new VersioningConfig { AssemblyVersionPrecision = precision } };
-        var service = CreateService(repo, config);
-        await Assert.That(service.AssemblyVersion).IsEqualTo(expected);
+        var version = CalculateVersion(repo, config);
+        await Assert.That(version.AssemblyVersion).IsEqualTo(expected);
     }
 
     [Test]
-    public async Task Constructor_DefaultPrecision_IsMajor()
+    public async Task Calculate_DefaultPrecision_IsMajor()
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "2.3\n");
         repo.CommitAll();
-        var service = CreateService(repo, new BuildvanaConfig());
-        await Assert.That(service.AssemblyVersion).IsEqualTo("2.0.0.0");
+        var version = CalculateVersion(repo, new BuildvanaConfig());
+        await Assert.That(version.AssemblyVersion).IsEqualTo("2.0.0.0");
     }
 
     [Test]
-    public async Task Constructor_FileVersion_IsFullPrecisionRegardlessOfAssemblyVersionPrecision()
+    public async Task Calculate_FileVersion_IsFullPrecisionRegardlessOfAssemblyVersionPrecision()
     {
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "2.3\n");
         repo.CommitAll();
-        var service = CreateService(repo, new BuildvanaConfig());
-        await Assert.That(service.FileVersion).IsEqualTo("2.3.1.0");
+        var version = CalculateVersion(repo, new BuildvanaConfig());
+        await Assert.That(version.FileVersion).IsEqualTo("2.3.1.0");
     }
 
-    private static VersioningService CreateService(TempGitRepo repo, BuildvanaConfig config)
-        => new(
-            NullReporter.Instance,
+    private static VersionInfo CalculateVersion(TempGitRepo repo, BuildvanaConfig config)
+        => new VersionCalculator(
             new FixedHomeDirectoryProvider(repo.RootPath),
             new VersioningSettings(config),
-            new GitHeightCalculator(VersionFile.FileName));
+            new GitHeightCalculator(VersionFile.FileName)).Calculate();
 
-    private static BuildFailedException? CatchCreate(TempGitRepo repo, BuildvanaConfig config)
+    private static BuildFailedException? CatchCalculate(TempGitRepo repo, BuildvanaConfig config)
     {
         try
         {
-            _ = CreateService(repo, config);
+            _ = CalculateVersion(repo, config);
             return null;
         }
         catch (BuildFailedException e)

--- a/tests/Buildvana.Sdk.Tasks.Tests/ComputeVersionTests.cs
+++ b/tests/Buildvana.Sdk.Tasks.Tests/ComputeVersionTests.cs
@@ -34,6 +34,20 @@ internal sealed class ComputeVersionTests
         await Assert.That(task.Height).IsEqualTo(1);
     }
 
+    // A repository with no commits has no HEAD to name, and MSBuild properties have no null: the task hands
+    // the build an empty string rather than letting the missing commit ID through as one.
+    [Test]
+    public async Task Execute_WithoutCommits_ReportsAnEmptyCommitId()
+    {
+        using var repo = new TempGitRepo();
+        repo.WriteFile("VERSION", "1.2\n");
+        var task = RunTask(repo);
+        await Assert.That(task.CommitId).IsEqualTo(string.Empty);
+        await Assert.That(task.Height).IsEqualTo(0);
+        await Assert.That(task.SemVer).IsEqualTo("1.2.0");
+        await Assert.That(task.InformationalVersion).IsEqualTo("1.2.0");
+    }
+
     [Test]
     public async Task Execute_WithConfigurationFile_HonorsVersioningSettings()
     {

--- a/tests/Buildvana.Sdk.Tasks.Tests/ComputeVersionTests.cs
+++ b/tests/Buildvana.Sdk.Tasks.Tests/ComputeVersionTests.cs
@@ -63,9 +63,9 @@ internal sealed class ComputeVersionTests
         var secondEngine = new RecordingBuildEngine();
         var second = RunTask(repo, secondEngine);
 
-        // The versioning service logs the computed version; a cache hit computes nothing and stays silent.
-        await Assert.That(firstEngine.Messages.Count(m => m.Message!.Contains("Version 1.2.1", StringComparison.Ordinal))).IsEqualTo(1);
-        await Assert.That(secondEngine.Messages.Count(m => m.Message!.Contains("Version 1.2.1", StringComparison.Ordinal))).IsEqualTo(0);
+        // Computing the version reports it; a cache hit computes nothing and stays silent.
+        await Assert.That(firstEngine.Messages.Count(m => m.Message!.Contains("Computed version 1.2.1", StringComparison.Ordinal))).IsEqualTo(1);
+        await Assert.That(secondEngine.Messages.Count(m => m.Message!.Contains("Computed version 1.2.1", StringComparison.Ordinal))).IsEqualTo(0);
         await Assert.That(second.SemVer).IsEqualTo("1.2.1");
         await Assert.That(second.Height).IsEqualTo(1);
     }
@@ -83,7 +83,7 @@ internal sealed class ComputeVersionTests
         var second = RunTask(repo, engine);
         await Assert.That(second.Height).IsEqualTo(2);
         await Assert.That(second.SemVer).IsEqualTo("1.2.2");
-        await Assert.That(engine.Messages.Count(m => m.Message!.Contains("Version 1.2.2", StringComparison.Ordinal))).IsEqualTo(1);
+        await Assert.That(engine.Messages.Count(m => m.Message!.Contains("Computed version 1.2.2", StringComparison.Ordinal))).IsEqualTo(1);
     }
 
     [Test]

--- a/tests/Buildvana.Sdk.Tasks.Tests/ComputeVersionTests.cs
+++ b/tests/Buildvana.Sdk.Tasks.Tests/ComputeVersionTests.cs
@@ -51,11 +51,16 @@ internal sealed class ComputeVersionTests
     [Test]
     public async Task Execute_WithConfigurationFile_HonorsVersioningSettings()
     {
+        const string config = """
+            {
+              "release": { "branches": ["^rel$"] },
+              "versioning": { "prereleaseTag": "preview", "assemblyVersionPrecision": "minor" }
+            }
+            """;
+
         using var repo = new TempGitRepo();
         repo.WriteFile("VERSION", "1.2-x\n");
-        repo.WriteFile(
-            "buildvana.json",
-            """{ "release": { "branches": ["^rel$"] }, "versioning": { "prereleaseTag": "preview", "assemblyVersionPrecision": "minor" } }""");
+        repo.WriteFile("buildvana.json", config);
         repo.CommitAll();
         repo.CheckoutNewBranch("rel");
         var task = RunTask(repo);
@@ -78,8 +83,8 @@ internal sealed class ComputeVersionTests
         var second = RunTask(repo, secondEngine);
 
         // Computing the version reports it; a cache hit computes nothing and stays silent.
-        await Assert.That(firstEngine.Messages.Count(m => m.Message!.Contains("Computed version 1.2.1", StringComparison.Ordinal))).IsEqualTo(1);
-        await Assert.That(secondEngine.Messages.Count(m => m.Message!.Contains("Computed version 1.2.1", StringComparison.Ordinal))).IsEqualTo(0);
+        await Assert.That(CountVersionMessages(firstEngine, "1.2.1")).IsEqualTo(1);
+        await Assert.That(CountVersionMessages(secondEngine, "1.2.1")).IsEqualTo(0);
         await Assert.That(second.SemVer).IsEqualTo("1.2.1");
         await Assert.That(second.Height).IsEqualTo(1);
     }
@@ -97,7 +102,7 @@ internal sealed class ComputeVersionTests
         var second = RunTask(repo, engine);
         await Assert.That(second.Height).IsEqualTo(2);
         await Assert.That(second.SemVer).IsEqualTo("1.2.2");
-        await Assert.That(engine.Messages.Count(m => m.Message!.Contains("Computed version 1.2.2", StringComparison.Ordinal))).IsEqualTo(1);
+        await Assert.That(CountVersionMessages(engine, "1.2.2")).IsEqualTo(1);
     }
 
     [Test]
@@ -124,4 +129,7 @@ internal sealed class ComputeVersionTests
         _ = task.Execute();
         return task;
     }
+
+    private static int CountVersionMessages(RecordingBuildEngine engine, string semVer)
+        => engine.Messages.Count(m => m.Message!.Contains($"Computed version {semVer}", StringComparison.Ordinal));
 }

--- a/tests/Buildvana.Tool.Tests/ReleaseCommandReportingTests.cs
+++ b/tests/Buildvana.Tool.Tests/ReleaseCommandReportingTests.cs
@@ -15,6 +15,19 @@
 [NotInParallel]
 internal sealed class ReleaseCommandReportingTests
 {
+    // The version is the one thing a release run is about, and it is stated once, after everything that
+    // could still move it has happened: the version the line names is the version that gets published.
+    [Test]
+    public async Task Release_RecordsTheVersionItPublishes()
+    {
+        using var harness = new ReleaseHarness(new() { Dogfood = false });
+
+        var exitCode = await harness.RunAsync().ConfigureAwait(false);
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        await Assert.That(harness.Notices).Contains($"Releasing version {harness.ComputeVersion()}.");
+    }
+
     // Asking for a prerelease line that is already a prerelease line changes nothing, which is a decision
     // worth recording: the release goes on, and the version file it leaves behind is the one it found.
     [Test]

--- a/tests/Buildvana.Tool.Tests/ReleaseCommandReportingTests.cs
+++ b/tests/Buildvana.Tool.Tests/ReleaseCommandReportingTests.cs
@@ -26,6 +26,7 @@ internal sealed class ReleaseCommandReportingTests
 
         await Assert.That(exitCode).IsEqualTo(0);
         await Assert.That(harness.Notices).Contains($"Releasing version {harness.ComputeVersion()}.");
+        await Assert.That(harness.Notices.Count(x => x.StartsWith("Releasing version", StringComparison.Ordinal))).IsEqualTo(1);
     }
 
     // Asking for a prerelease line that is already a prerelease line changes nothing, which is a decision

--- a/tests/Buildvana.Tool.Tests/ReleaseHarness.cs
+++ b/tests/Buildvana.Tool.Tests/ReleaseHarness.cs
@@ -165,12 +165,11 @@ internal sealed class ReleaseHarness : IDisposable
     public string ComputeVersion()
     {
         var config = new BuildvanaConfig { Versioning = new VersioningConfig { PrereleaseTag = "preview" } };
-        var versioning = new VersioningService(
-            NullReporter.Instance,
+        var calculator = new VersionCalculator(
             new FixedHomeDirectoryProvider(Repo.RootPath),
             new VersioningSettings(config),
             new GitHeightCalculator(VersionFile.FileName));
-        return versioning.SemVer;
+        return calculator.Calculate().SemVer;
     }
 
     /// <summary>


### PR DESCRIPTION
### Description

`bv release` printed the same version line up to twenty-two times per run — four in a row at the head of each pipeline stage, plus two from `bv` itself.

The cause is that `VersioningService` reported the computed version from its constructor. That made the message count a function of how many instances got built, which in the SDK means one per MSBuild node, since the `ComputeVersion` cache is per process. Four lines on a 4-vCPU CI runner; twenty-nine on a 32-core desktop. Nothing about the repository determines it.

The class had a second problem behind the first: it was named a service but behaved as a snapshot. It computed everything in its constructor, `VersionService.Update()` discarded the instance and built another, and the SDK task copied its ten properties into an identically shaped record.

So it is now the pair its own project already establishes with `GitHeightCalculator` → `GitHeightResult`:

- `VersionInfo` — the immutable snapshot, deriving the five version strings from the spec, the height, and the settings. No I/O, and an `internal` constructor: `VersionCalculator` is the only thing that builds one, so the one place that has to get the parameters consistent is the only place that can pass them.
- `VersionCalculator` — the lookups (version file, prerelease tag validation, height walk), returning a `VersionInfo`. Stateless, so calculating again after a commit is the explicit way to get a second answer.

`IReporter` is out of `Buildvana.Core.Versioning` altogether. `CachedVersion` collapses to `(Fingerprint, VersionInfo)` and stays inside the caching partial. Reporting now happens in exactly two deliberate places:

- the SDK task, at **detail** level (`MessageImportance.Low`), invisible below `-v detailed`, where per-node repetition is a diagnostic rather than noise — and where `ComputeVersionTests` reads it as evidence of a cache hit;
- `bv release`, once, just after the tag check — the last thing that can refuse this particular version — where naming it records a decision rather than a guess.

`bv build`/`pack` say nothing about the version, as before.

One consequence worth stating plainly: a release that fails before that point no longer names a version at the default verbosity. What it used to name was a guess — `VersionService` is resolved at the top of the command, before the version spec change and before the release commit, so the old line reported a height at least one below the version that would be published, and named a different version line entirely on a `--bump` run. `-v detailed` still carries the SDK task's line for anyone who wants the provisional number.

### Additional changes

None.

### Checklist

- [x] Build is clean: 0 errors, 0 warnings
- [x] Sanity check green (`bv pack` + ReSharper at WARNING and above, both silent)
- [x] Tests pass: Core.Versioning 102, Sdk.Tasks 41, Tool 399 — including `Release_RecordsTheVersionItPublishes`, which asserts the line appears exactly once
- [x] No changelog entry — the versioning feature is still under _Unreleased changes_ and never documented the line
